### PR TITLE
Page not found HTTP Status Codes

### DIFF
--- a/lib/locomotive/render.rb
+++ b/lib/locomotive/render.rb
@@ -9,7 +9,7 @@ module Locomotive
 
       def render_locomotive_page
         if request.fullpath =~ /^\/admin\//
-          render :template => "/admin/errors/404", :layout => '/admin/layouts/box', :status => 404
+          render :template => "/admin/errors/404", :layout => '/admin/layouts/box', :status => :not_found
         else
           @page = locomotive_page
 
@@ -52,7 +52,7 @@ module Locomotive
           end
         end
 
-        page || current_site.pages.not_found.published.first
+        page || not_found_page
       end
 
       def locomotive_context
@@ -93,11 +93,19 @@ module Locomotive
           end
         end
 
-        render :text => output, :layout => false, :status => :ok
+        render :text => output, :layout => false, :status => page_status
+      end
+
+      def not_found_page
+        current_site.pages.not_found.published.first
       end
 
       def editing_page?
         self.params[:editing] == true && current_admin
+      end
+
+      def page_status
+        @page == not_found_page ? :not_found : :ok
       end
 
     end

--- a/spec/lib/locomotive/render_spec.rb
+++ b/spec/lib/locomotive/render_spec.rb
@@ -22,6 +22,10 @@ describe 'Locomotive rendering system' do
       @controller.response.headers['Content-Type'].should == 'text/html; charset=utf-8'
     end
 
+    it 'sets the status to 200 OK' do
+      @controller.status.should == :ok
+    end
+
     it 'displays the output' do
       @controller.output.should == 'Hello world !'
     end
@@ -44,6 +48,12 @@ describe 'Locomotive rendering system' do
       @controller.send(:prepare_and_set_response, 'Hello world !')
       @controller.response.to_a # force to build headers
       @controller.response.headers['Cache-Control'].should == 'max-age=3600, public'
+    end
+
+    it 'sets the status to 404 not found when no page is found' do
+      @controller.expects(:not_found_page).times(1..100).returns(@page)
+      @controller.send(:prepare_and_set_response, 'Hello world !')
+      @controller.status.should == :not_found
     end
 
   end

--- a/spec/support/locomotive.rb
+++ b/spec/support/locomotive.rb
@@ -8,10 +8,11 @@ module Locomotive
 
     include Locomotive::Render
 
-    attr_accessor :output, :current_site, :current_admin
+    attr_accessor :output, :status, :current_site, :current_admin
 
     def render(options = {})
       self.output = options[:text]
+      self.status = options[:status]
     end
 
     def response


### PR DESCRIPTION
When the 404 page is rendered, the HTTP status code is 200 OK. This could cause issues with search engines indexing pages that do not exist.

I've included a patch to the rendering to show 404 Not Found when rendering the not found page.
