### PR TITLE
Dollar cmd s

### DIFF
--- a/config/assets.yml
+++ b/config/assets.yml
@@ -12,6 +12,7 @@ javascripts:
     - public/javascripts/admin/jquery.ui.js
     - public/javascripts/admin/rails.js
     - public/javascripts/admin/utils.js
+    - public/javascripts/admin/plugins/cmd.js
     - public/javascripts/admin/plugins/subscribe.js
     - public/javascripts/admin/plugins/shortcut.js
     - public/javascripts/admin/plugins/toggle.js

--- a/public/javascripts/admin/plugins/cmd.js
+++ b/public/javascripts/admin/plugins/cmd.js
@@ -1,0 +1,13 @@
+$.cmd = function(key, callback, args) {
+    var isCtrl = false;
+    $(document).keydown(function(e) {
+      if(!args) args=[]; // IE barks when args is null
+      if(e.metaKey) isCtrl = true;
+      if(e.keyCode == key.charCodeAt(0) && isCtrl) {
+        callback.apply(this, args);
+        return false;
+      }
+    }).keyup(function(e) {
+        if(e.ctrlKey) isCtrl = false;
+    });
+};

--- a/public/javascripts/admin/plugins/shortcut.js
+++ b/public/javascripts/admin/plugins/shortcut.js
@@ -43,8 +43,7 @@ jQuery.fn.saveWithShortcut = function() {
 	return this.each(function() {
 		var form = jQuery(this);
 		
-		jQuery(document).bind('keypress.shortcut', function(event) {
-			if (!(event.which == 115 && (event.ctrlKey || event.metaKey))) return true;
+		$.cmd('S', function() {
 			updateFromCodeMirror();
 			save(form);
 			event.preventDefault();


### PR DESCRIPTION
adds the method

```
$.cmd('blah', function() {
  //something
});
```

which I then use for the page and snippet saving, gives better cross browser support, and another piece of reusable code.
