### PR TITLE
Add or update editable element

### DIFF
--- a/lib/locomotive/liquid/tags/editable/base.rb
+++ b/lib/locomotive/liquid/tags/editable/base.rb
@@ -19,14 +19,18 @@ module Locomotive
           end
 
           def end_tag
-            @context[:page].add_or_update_editable_element({
-              :block => @context[:current_block].try(:name),
-              :slug => @slug,
-              :hint => @options[:hint],
-              :default_content => @nodelist.first.to_s,
-              :disabled => false,
-              :from_parent => false
-            }, document_type)
+            super
+            
+            if @context[:page].present?
+              @context[:page].add_or_update_editable_element({
+                :block => @context[:current_block].try(:name),
+                :slug => @slug,
+                :hint => @options[:hint],
+                :default_content => @nodelist.first.to_s,
+                :disabled => false,
+                :from_parent => false
+              }, document_type)
+            end
           end
 
           def render(context)


### PR DESCRIPTION
Was getting exceptions when updating a layout (or snippet) which contained an editable area.

This included when doing an import over an existing system.

Reason is that the admin system doesn't have a page reference in the context object, checked for presence before running the editable area end tag.
