### PR TITLE
Bug: Current site name does not update

### DIFF
--- a/app/views/admin/current_sites/edit.html.haml
+++ b/app/views/admin/current_sites/edit.html.haml
@@ -1,4 +1,4 @@
-- title link_to(@site.name.blank? ? @site.name_was : @site.name, '#', :rel => 'current_site_name', :title => t('.ask_for_name'), :class => 'editable')
+- title link_to(@site.name.blank? ? @site.name_was : @site.name, '#', :rel => 'site_name', :title => t('.ask_for_name'), :class => 'editable')
 
 - content_for :submenu do
   = render 'admin/shared/menu/settings'


### PR DESCRIPTION
On the current site edit page: The rel attribute for the editable name field up top is incorrectly set to current_site_name. The hidden input field is site_name so it doesn't update. See commit for the small fix.
