### PR TITLE
Liquid tag for displaying SEO Metadata (description and keywords)

### DIFF
--- a/lib/locomotive/liquid/tags/seo_metadata.rb
+++ b/lib/locomotive/liquid/tags/seo_metadata.rb
@@ -1,0 +1,23 @@
+module Locomotive
+  module Liquid
+    module Tags
+      class SEOMetadata < ::Liquid::Tag
+
+        def render(context)
+          %{
+            <meta name="description" content="#{sanitized_string(context.registers[:site].meta_description)}" />
+            <meta name="keywords" content="#{sanitized_string(context.registers[:site].meta_keywords)}" />
+          }
+        end
+
+        # Removees whitespace and quote charactets from the input
+        def sanitized_string(string)
+          string.strip.gsub(/"/, '')
+        end
+
+      end
+
+      ::Liquid::Template.register_tag('seo_metadata', SEOMetadata)
+    end
+  end
+end

--- a/spec/lib/locomotive/liquid/tags/seo_metadata_spec.rb
+++ b/spec/lib/locomotive/liquid/tags/seo_metadata_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Locomotive::Liquid::Tags::SEOMetadata do
+
+  before :each do
+    @site = Factory.build(:site, :meta_description => 'A short site description', :meta_keywords => 'test only cat dog')
+  end
+
+  context '#rendering' do
+
+    it 'renders a a meta description tag' do
+      render_seo_metadata.should include '<meta name="description" content="A short site description" />'
+    end
+
+    it 'strips and removes quote characters from the description' do
+      @site.meta_description = ' String with " " quotes '
+      render_seo_metadata.should include '<meta name="description" content="String with   quotes" />'
+    end
+
+    it 'renders a meta keywords tag' do
+      render_seo_metadata.should include '<meta name="keywords" content="test only cat dog" />'
+    end
+
+    it 'strips and removes quote characters from the keywords' do
+      @site.meta_keywords = ' one " two " three '
+      render_seo_metadata.should include '<meta name="keywords" content="one  two  three" />'
+    end
+
+  end
+
+  def render_seo_metadata
+    registers = { :site => @site }
+    liquid_context = ::Liquid::Context.new({}, {}, registers)
+    output = Liquid::Template.parse("{% seo_metadata %}").render(liquid_context)
+  end
+
+
+end


### PR DESCRIPTION
I've added support for a new tag to display the sites description and keywords easily. It automatically strips the string (removes whitespace from the beginning and end) and it also removes quote characters to not break the HTML output.

The tag: {% seo_metadata %} 
Outputs: <meta name="description" content="description" /> 
             <meta name="keywords" content="keywords" />
