### PR TITLE
theme_image_tag liquid filter

### DIFF
--- a/lib/locomotive/liquid/filters/html.rb
+++ b/lib/locomotive/liquid/filters/html.rb
@@ -38,6 +38,16 @@ module Locomotive
 
           asset_url(input)
         end
+        
+        # Write a theme image tag
+        # input: name of file including folder
+        # example: 'about/myphoto.jpg' | theme_image # <img src="images/about/myphoto.jpg" />
+        def theme_image_tag(input, *args)
+          return '' if input.nil?
+          input = "images/#{input}" unless input.starts_with?('/')
+          image_options = inline_options(args_to_options(args))
+          "<img src=\"#{asset_url(input)}\" #{image_options}/>"
+        end
 
         # Write an image tag
         # input: url of the image OR asset drop

--- a/spec/lib/locomotive/liquid/filters/html_spec.rb
+++ b/spec/lib/locomotive/liquid/filters/html_spec.rb
@@ -44,6 +44,14 @@ describe Locomotive::Liquid::Filters::Html do
     javascript_tag('/trash/main.js').should == result
     javascript_tag('/trash/main').should == result
   end
+  
+  it 'should return an image tag for a given theme file without parameters' do
+    theme_image_tag('foo.jpg').should == "<img src=\"/sites/000000000000000000000042/theme/images/foo.jpg\" />"
+  end
+  
+  it 'should return an image tag for a given theme file with size' do
+    theme_image_tag('foo.jpg', 'width:100', 'height:100').should == "<img src=\"/sites/000000000000000000000042/theme/images/foo.jpg\" height=\"100\" width=\"100\" />"
+  end
 
   it 'should return an image tag without parameters' do
     image_tag('foo.jpg').should == "<img src=\"foo.jpg\" />"


### PR DESCRIPTION
Have just finished building my first theme with Locomotive and ran across the issue of including a theme image using an image_tag. The process was quite messy and figured a theme_image_tag filter was a good idea.

Specced up and ready to roll.
