### PR TITLE
Fix for snippets nested in blocks not being updated

### DIFF
--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -15,8 +15,6 @@ class Snippet
   after_save :update_templates
   after_destroy :update_templates
 
-  # TODO: after_save callback to let pages embedding this snippet know about the changes the user has just made.
-
   ## validations ##
   validates_presence_of   :site, :name, :slug, :template
   validates_uniqueness_of :slug, :scope => :site_id
@@ -50,15 +48,14 @@ class Snippet
     when Locomotive::Liquid::Tags::Snippet
       node.refresh(self) if node.slug == self.slug
     when Locomotive::Liquid::Tags::InheritedBlock
-      self._change_snippet_inside_template(node.parent) if node.parent
-    else
-      if node.respond_to?(:nodelist)
-        (node.nodelist || []).each do |child|
-          self._change_snippet_inside_template(child)
-        end
+      _change_snippet_inside_template(node.parent) if node.parent
+    end
+    # Walk the children of this entry if they're available.
+    if node.respond_to?(:nodelist)
+      (node.nodelist || []).each do |child|
+        self._change_snippet_inside_template(child)
       end
     end
   end
-
 
 end

--- a/spec/models/snippet_spec.rb
+++ b/spec/models/snippet_spec.rb
@@ -16,4 +16,39 @@ describe Snippet do
     end
   end
 
+  describe '#update_templates' do
+  
+    before :each do
+      @site    = Factory(:site, :subdomain => 'omg')
+      @snippet = Factory(:snippet, :site => @site, :slug => 'my_test_snippet', :template => 'a testing template')
+    end
+
+    context 'with a normal top level snippet' do
+
+      before :each do
+        @page = Factory(:page, :site => @site, :slug => 'my_page_here', :raw_template => "{% include 'my_test_snippet'  %}")
+      end
+
+      it 'updates templates with the new snippet template' do
+        @snippet.update_attributes(:template => 'a new template')
+        Page.find(@page.id).render({}).should == 'a new template'
+      end
+
+    end
+
+    context 'for snippets inside of a block' do
+
+      before :each do
+        @page = Factory(:page, :site => @site, :slug => 'my_page_here', :raw_template => "{% block main %}{% include 'my_test_snippet'  %}{% endblock %}")
+      end
+
+      it 'updates templates with the new snippet template' do
+        @snippet.update_attributes(:template => 'a new template')
+        Page.find(@page.id).render({}).should == 'a new template'
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
We managed to find a bug that would prevent templates from being updated when snippets were embedded inside of a block.

Also, the attached commits come complete with specs for extra-special-fun-time.
