### PR TITLE
Image sizing

### DIFF
--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -54,7 +54,8 @@ class AssetUploader < CarrierWave::Uploader::Base
 
   def set_width_and_height
     if model.image?
-      model.width, model.height = `identify -format "%wx%h" #{file.path}`.split(/x/).collect(&:to_i)
+      magick = ::Magick::Image.read(current_path).first
+      model.width, model.height = magick.columns, magick.rows
     end
   end
 


### PR DESCRIPTION
This is a pretty straightforward change to the way image sizes are calculated for caching. I actually had a problem where the identify command wasn't working via Passenger (but was through irb). This just uses rmagick to get the values, which seems like a good idea anyway

Cheers
