### PR TITLE
Version of mongo requires bson_ext version >= 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'warden'
 gem 'devise', '= 1.1.3'
 
 gem 'mongoid', '2.0.0.rc.7'
-gem 'bson_ext', '~> 1.2.1'
+gem 'bson_ext', '1.3.0'
 gem 'locomotive_mongoid_acts_as_tree', '0.1.5.5', :require => 'mongoid_acts_as_tree'
 gem 'will_paginate'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       ZenTest (>= 4.4.1)
     bcrypt-ruby (2.1.4)
     bson (1.2.4)
-    bson_ext (1.2.4)
+    bson_ext (1.3.0)
     builder (2.1.2)
     capybara (0.4.0)
       celerity (>= 0.7.9)
@@ -263,7 +263,7 @@ DEPENDENCIES
   ZenTest
   actionmailer-with-request
   autotest
-  bson_ext (~> 1.2.1)
+  bson_ext (= 1.3.0)
   capybara
   cucumber (= 0.8.5)
   cucumber-rails

--- a/locomotive_cms.gemspec
+++ b/locomotive_cms.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "warden"
   s.add_dependency "devise", "1.1.3"
   s.add_dependency "mongoid", "2.0.0.rc.7"
-  s.add_dependency "bson_ext", "~> 1.2.0"
+  s.add_dependency "bson_ext", "1.3.0"
   s.add_dependency "locomotive_mongoid_acts_as_tree", "0.1.5.5"
   s.add_dependency "will_paginate"
 


### PR DESCRIPTION
Was getting warnings about version of bson_ext. Upgrading seemed to solve the issue.

All tests pass.
