### PR TITLE
fixed problem with pagination url, it was creating a relative path instea

### DIFF
--- a/lib/locomotive/liquid/filters/html.rb
+++ b/lib/locomotive/liquid/filters/html.rb
@@ -82,13 +82,13 @@ module Locomotive
           previous_link = (if paginate['previous'].blank?
             "<span class=\"disabled prev_page\">#{previous_label}</span>"
           else
-            "<a href=\"#{paginate['previous']['url']}\" class=\"prev_page\">#{previous_label}</a>"
+            "<a href=\"/#{paginate['previous']['url']}\" class=\"prev_page\">#{previous_label}</a>"
           end)
 
           links = ""
           paginate['parts'].each do |part|
             links << (if part['is_link']
-              "<a href=\"#{part['url']}\">#{part['title']}</a>"
+              "<a href=\"/#{part['url']}\">#{part['title']}</a>"
             elsif part['hellip_break']
               "<span class=\"gap\">#{part['title']}</span>"
             else
@@ -99,7 +99,7 @@ module Locomotive
           next_link = (if paginate['next'].blank?
             "<span class=\"disabled next_page\">#{next_label}</span>"
           else
-            "<a href=\"#{paginate['next']['url']}\" class=\"next_page\">#{next_label}</a>"
+            "<a href=\"/#{paginate['next']['url']}\" class=\"next_page\">#{next_label}</a>"
           end)
 
           %{<div class="pagination #{options[:css]}">


### PR DESCRIPTION
fixed problem with pagination url, it was creating a relative path instead of an absolute path

e.g.

events page displays 5 items per page (paginate)

events url: <domain>/events
pagination-url for next page = "events?page=2"

the url to be requested now is: "<domain>/events/events?page=2" instead of "<domain>/events?page=2"
