### PR TITLE
Recursive Loop Fix

### DIFF
--- a/app/models/extensions/page/parse.rb
+++ b/app/models/extensions/page/parse.rb
@@ -94,6 +94,7 @@ module Models
 
             direct_descendants.each do |page|
               unless visited.include? page.id
+                visited.push(page.id)
                 page.send(:_parse_and_serialize_template, { :cached_parent => self, :cached_pages => cached })
 
                 page.send(:_update_direct_template_descendants, template_descendants, cached, visited)


### PR DESCRIPTION
When updating a page in a particular template of ours the entire application would crash due to a recursive loop.

We're still investigating the process to avoid this being called by templates, but this commit means we can avoid it ever happening in the future.
