### PR TITLE
error in image processing of uploaded files in gembump branch

### DIFF
--- a/lib/locomotive/carrierwave/asset.rb
+++ b/lib/locomotive/carrierwave/asset.rb
@@ -30,6 +30,7 @@ module Locomotive
 
         module InstanceMethods
 
+          include ::CarrierWave::RMagick
           def set_content_type(*args)
             value = :other
 


### PR DESCRIPTION
I have found uninitialized constant Magick error when uploading image to assets.

Default tests (not modified by me) in spec/models/theme_asset_spec.rb failed - https://gist.github.com/1054123

After a while I tried to add
```include ::CarrierWave::RMagick

```
to InstanceMethods module in lib/locomotive/carrierwave/asset.rb and tests passed.

I have run tests from spec/models/theme_asset_spec.rb only.
```
