### PR TITLE
Fix asset uploading on heroku with source installation

### DIFF
--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -2,6 +2,7 @@
 
 class AssetUploader < CarrierWave::Uploader::Base
 
+  include CarrierWave::RMagick
   include Locomotive::CarrierWave::Uploader::Asset
 
   def store_dir


### PR DESCRIPTION
Before this patch asset uploading would fail on heroku with an error like this "NameError: uninitialized constant Magick"

It only seems to fail with this error if installed from source on heroku or bushido.  If installed locally in developement or if installed via the rails engine to heroku it seems to upload correctly with no error.
