### PR TITLE
Quick patch for has_many bug in IE

### DIFF
--- a/public/javascripts/admin/custom_fields/has_many.js
+++ b/public/javascripts/admin/custom_fields/has_many.js
@@ -27,7 +27,11 @@ $(document).ready(function() {
           if (size > 0) context.select.append(optgroup);
         } else {
           if ($.inArray(obj[1], context.data.taken_ids) == -1)
-            context.select.append(new Option(obj[0], obj[1], true, true));
+          {
+            var option = new Option("", obj[1], true, true);
+            $(option).text(obj[0]);
+            context.select.append(option);
+          }
         }
       }
 


### PR DESCRIPTION
Mostly fixes issue #121. Now there's another problem: when an item is added or removed, the "select" element is notupdated accordingly. It appears that the code to update the select is being run correctly, but the DOM is stubbornly refusing to change the options in the select. As a workaround, clicking the "update" button will update the select options.

This works in IE 8. If anyone cares to test it in other versions, that would be great.
