### PR TITLE
Fix usage of HEROKU_LOGIN and HEROKU_PASSWORD for specifying Heroku credentials

### DIFF
--- a/lib/locomotive/hosting/heroku/enabler.rb
+++ b/lib/locomotive/hosting/heroku/enabler.rb
@@ -38,8 +38,8 @@ module Locomotive
           end
 
           def open_heroku_connection
-            login = self.config.heroku[:login] || ENV['HEROKU_LOGIN']
-            password = self.config.heroku[:password] || ENV['HEROKU_PASSWORD']
+            login = ENV['HEROKU_LOGIN'] || self.config.heroku[:login]
+            password = ENV['HEROKU_PASSWORD'] || self.config.heroku[:password]
 
             self.heroku_connection = ::Heroku::Client.new(login, password)
           end


### PR DESCRIPTION
Contrary to the claims on the documentation, it is currently not possible to use environment variables for the heroku credentials in Locomotive CMS. 

The offending code is in [lib/locomotive/hosting/heroku/enabler.rb#L41-42](https://github.com/locomotivecms/engine/blob/master/lib/locomotive/hosting/heroku/enabler.rb#L41-42)

```
login = self.config.heroku[:login] || ENV['HEROKU_LOGIN']
password = self.config.heroku[:password] || ENV['HEROKU_PASSWORD']
```

`self.config.heroku[:login]` and `self.config.heroku[:password]` never return a falsy value because `Locomotive.configuration` is a `ConfigurationHash`, whose default value is a `ConfigurationHash`. Therefore, when `Locomotive.config.heroku[:login]` and `Locomotive.config.heroku[:password]` are not set, Locomotive CMS blows up on Heroku even when the environment variables `HEROKU_LOGIN` and `HEROKU_PASSWORD` are properly set.

Since storing credentials in a file under version control is a bad practice, I propose flipping the logic so that `ENV['HEROKU_LOGIN']` and `ENV['HEROKU_PASSWORD']` take precedence when set. This is also more in line with how environment variables are usually used (to override a setting in code).
