### PR TITLE
Support multiple templatized pages in a single URL

### DIFF
--- a/lib/locomotive/render.rb
+++ b/lib/locomotive/render.rb
@@ -33,25 +33,26 @@ module Locomotive
         path.gsub!(/^\//, '')
         path = 'index' if path.blank?
 
-        if path != 'index'
-          dirname = File.dirname(path).gsub(/^\.$/, '') # also look for templatized page path
-          path = [path, File.join(dirname, 'content_type_template').gsub(/^\//, '')]
-        end
+        page = nil
+        parents = []
+        @content_instances = ActiveSupport::OrderedHash.new
 
-        if page = current_site.pages.any_in(:fullpath => [*path]).first
-          if not page.published? and current_admin.nil?
-            page = nil
-          else
+        path.split('/').each do |slug|
+          paths = []
+          paths << parents + [ slug ]
+          paths << parents + [ "content_type_template" ] unless paths == [[ "index" ]]
+          paths.map! { |p| p.join '/' }
+          if page = current_site.pages.any_in(:fullpath => paths).sort_by { |p| p.templatized.to_s }.first
+            parents << page.slug
             if page.templatized?
-              @content_instance = page.content_type.contents.where(:_slug => File.basename(path.first)).first
-
-              if @content_instance.nil? || (!@content_instance.visible? && current_admin.nil?) # content instance not found or not visible
-                page = nil
-              end
+              @content_instance = page.content_type.contents.where(:_slug => slug).first
+              @content_instances[page.content_type.slug.singularize] = @content_instance
+              page = nil if @content_instance.nil? || (!@content_instance.visible? && current_admin.nil?) # content instance not found or not visible
             end
           end
+          break unless page
         end
-
+        page = nil if page and not page.published? and current_admin.nil?
         page || not_found_page
       end
 
@@ -68,9 +69,10 @@ module Locomotive
           'today'             => Date.today
         }.merge(flash.stringify_keys) # data from api
 
-        if @page.templatized? # add instance from content type
+        if @page.templatized? 
           assigns['content_instance'] = @content_instance
-          assigns[@page.content_type.slug.singularize] = @content_instance # just here to help to write readable liquid code
+          assigns['content_instances'] = @content_instances.values
+          @content_instances.each { |k,v| assigns[k] = v } # just here to help to write readable liquid code
         end
 
         registers = {


### PR DESCRIPTION
This is a rough patch that supports everything that we talked about in this issue: #82
1. Multiple templatized pages in a single URL
2. Prefer static pages over templatized pages
3. Set liquid variables for all templatized pages

There are (at least) a few issues with this patch:
1. Needs to be optimized, particularly for paths with no templatized pages
2. Fails 4/18 of the render specs - this is because I am passing different arguments to site.pages.any_in

I don't expect this to be merged, but hopefully this will serve as a good starting point for a discussion about how to implement these features.

Let me know what you think!

Cheers,
Isaac
