### PR TITLE
Prevent strange Capybara test failures because of missing entry in /etc/hosts

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,10 +19,25 @@ require 'capybara/rails'
 require 'capybara/cucumber'
 require 'capybara/session'
 
+require 'resolv'
+require 'uri'
+
+def ensure_host_resolution(app_host)
+  hosts = Resolv::Hosts.new
+  app_host_name = URI.parse(app_host).host
+  begin
+    hosts.getaddress(app_host_name)
+  rescue Resolv::ResolvError
+    raise "Unable to resolve ip address for #{app_host_name}. Please consider adding an entry to '/etc/hosts' that associates #{app_host_name} with '127.0.0.1'."
+  end
+end
+
 Capybara.configure do |config|
   config.default_selector   = :css
   config.server_port        = 9886
   config.app_host           = 'http://test.example.com:9886'
+
+  ensure_host_resolution(config.app_host)
 end
 
 # Capybara.javascript_driver = :rack_test


### PR DESCRIPTION
Added test to make sure that test.example.com can be resolved through /etc/hosts.
