### PR TITLE
Cells gem not initialized in engine

### DIFF
--- a/lib/locomotive/engine.rb
+++ b/lib/locomotive/engine.rb
@@ -24,6 +24,7 @@ require 'jammit-s3'
 require 'dragonfly'
 require 'cancan'
 require 'RMagick'
+require 'cells'
 
 $:.unshift File.dirname(__FILE__)
 
@@ -31,6 +32,10 @@ module Locomotive
   class Engine < Rails::Engine
 
     config.autoload_once_paths += %W( #{config.root}/app/controllers #{config.root}/app/models #{config.root}/app/helpers #{config.root}/app/uploaders)
+
+    initializer "locomotive.cells" do |app|
+      Cell::Base.prepend_view_path("#{config.root}/app/cells")
+    end
 
     rake_tasks do
       load "railties/tasks.rake"


### PR DESCRIPTION
Hi

Locomotive does not currently work when installed as an engine because Cells is neither required nor configured with the proper view path. When you try to access the admin interface an "undefined method 'render_cell'" exception occurs. This patch fixes that.
