### PR TITLE
Page slugs hyphens

### DIFF
--- a/public/javascripts/admin/pages.js
+++ b/public/javascripts/admin/pages.js
@@ -62,7 +62,7 @@ $(document).ready(function() {
 
     if (!slug.hasClass('filled')) {
       setTimeout(function() {
-        slug.val(makeSlug(input.val())).addClass('touched');
+        slug.val(makeSlug(input.val(), '-')).addClass('touched');
       }, 50);
     }
   });


### PR DESCRIPTION
I think this has been resolved before, but it seems to have reverted.
Hyphens are more of a standard in CMS'
