### PR TITLE
Set up specs to use spork for faster test runs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --colour
+--drb

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,52 +1,62 @@
-# This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require 'rubygems'
+require 'spork'
 
-require 'rspec/rails'
-require 'factory_girl'
+Spork.prefork do
+  # This file is copied to spec/ when you run 'rails generate rspec:install'
+  ENV["RAILS_ENV"] ||= 'test'
+  require File.expand_path('../../config/environment', __FILE__)
 
-FactoryGirl.find_definitions
+  require 'rspec/rails'
+  require 'factory_girl'
+  Factory.find_definitions
 
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+  # Requires supporting ruby files with custom matchers and macros, etc,
+  # in spec/support/ and its subdirectories.
+  Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
-Locomotive.configure_for_test
+  Locomotive.configure_for_test
 
-RSpec.configure do |config|
+  RSpec.configure do |config|
 
-  config.include(Locomotive::RSpec::Matchers)
+    config.include(Locomotive::RSpec::Matchers)
 
-  # == Mock Framework
-  #
-  # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
-  #
-  config.mock_with :mocha
-  # config.mock_with :flexmock
-  # config.mock_with :rr
-  # config.mock_with :rspec
+    # == Mock Framework
+    #
+    # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
+    #
+    config.mock_with :mocha
+    # config.mock_with :flexmock
+    # config.mock_with :rr
+    # config.mock_with :rspec
 
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
+    # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+    # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  # config.use_transactional_fixtures = true
+    # If you're not using ActiveRecord, or you'd prefer not to run each of your
+    # examples within a transaction, remove the following line or assign false
+    # instead of true.
+    # config.use_transactional_fixtures = true
 
-  config.before(:each) do
-    Locomotive.config.heroku = false
-  end
+    config.before(:each) do
+      Locomotive.config.heroku = false
+    end
 
-  require 'database_cleaner'
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.orm = 'mongoid'
-  end
+    require 'database_cleaner'
+    config.before(:suite) do
+      DatabaseCleaner.strategy = :truncation
+      DatabaseCleaner.orm = 'mongoid'
+    end
 
-  config.before(:each) do
-    if self.described_class != Locomotive::Import::Job
-      DatabaseCleaner.clean
+    config.before(:each) do
+      if self.described_class != Locomotive::Import::Job
+        DatabaseCleaner.clean
+      end
     end
   end
+end
+
+Spork.each_run do
+  Locomotive.configure_for_test(true)
+  Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+  Dir[Rails.root.join('app/models/*.rb')].each { |f| load f }
 end


### PR DESCRIPTION
Hey everyone,

I've set up the configuration for specs so that they use spork. This allows for much faster test runs. On my machine a full test run takes about 50s. With spork, it takes 20s. Running a single spec file only takes a few seconds rather than half a minute.

There are two problems that I'm currently aware of. One is that spork preloads all files in the lib directory, so when testing a file in that directory (say, lib/locomotive/export.rb), changes to export.rb will not be automatically reloaded. The way I've been working around this is to add this code to export_spec.rb:

```
before(:all) do
  load File.join(Rails.root, 'lib', 'locomotive', 'export.rb')
end
```

There may be a better solution than this.

The other problem is that sone of the specs are failing and I'm not sure why. On my machine, a bunch of the specs fail anyway, but when using spork, there are more that fail. The additional failing specs all have similar error messages which look something like this:

```
Page should validate presence of site
Failure/Error: page.errors[field.to_sym].should == ["can't be blank"]
expected: ["can't be blank"]
    got: ["can't be blank", "can't be blank"] (using ==)
Diff:
@@ -1,2 +1,2 @@
-["can't be blank"]
+["can't be blank", "can't be blank"]
# ./spec/models/page_spec.rb:22:in `block (3 levels) in <top (required)>'
```

I don't know exactly where this problem lies, but the error messages seem consistent enough that someone who knows the codebase better than me could probably pinpoint it pretty quickly.

Enjoy!

Alex S.
