### PR TITLE
Added rake task to create new admin user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'locomotive_jammit-s3', :require => 'jammit-s3'
 gem 'SystemTimer', :platforms => :ruby_18
 gem 'cells'
 
+gem 'highline'
+
 # The rest of the dependencies are for use when in the locomotive dev environment
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,7 @@ DEPENDENCIES
   growl-glue
   haml (= 3.1.2)
   heroku (= 1.19.1)
+  highline
   httparty (>= 0.6.1)
   inherited_resources (~> 1.1.2)
   launchy

--- a/lib/tasks/locomotive.rake
+++ b/lib/tasks/locomotive.rake
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'locomotive'
+require 'highline/import'
 
 namespace :locomotive do
 
@@ -43,6 +44,21 @@ namespace :locomotive do
     end
 
     ::Locomotive::Import::Job.run!(url, site, { :samples => true, :reset => reset })
+  end
+
+  desc 'Add a new admin user (NOTE: currently only supports adding user to first site)'
+  task :add_admin => :environment do
+    name = ask('Display name: ') { |q| q.echo = true }
+    email = ask('Email address: ') { |q| q.echo = true }
+    password = ask('Password: ') { |q| q.echo = '*' }
+    password_confirm = ask('Confirm password: ') { |q| q.echo = '*' }
+
+    account = Account.create :email => email, :password => password, :password_confirmation => password_confirm, :name => name
+
+    # TODO: this should be changed to work for multi-sites (see desc)
+    site = Site.first
+    site.memberships.build :account => account, :role => 'admin'
+    site.save!
   end
 
   namespace :upgrade do


### PR DESCRIPTION
The title says it all. I screwed something up in the database recently and had to delete and recreate all the users from the heroku console. So I wrote a rake task. Note that for CMS's which host multiple sites, this will currently only add the admin user to the first site. If someone wants to make this work better, go ahead :)

Alex S.
