### PR TITLE
Adding indexes

### DIFF
--- a/app/models/extensions/page/tree.rb
+++ b/app/models/extensions/page/tree.rb
@@ -10,6 +10,10 @@ module Extensions
         ## fields ##
         field :position, :type => Integer
 
+        ## indexes ##
+        index :position
+        index [[:depth, :asc], [:position, :asc]]
+
         ## behaviours ##
         acts_as_tree :order => ['position', 'asc']
 


### PR DESCRIPTION
Adding indexes on :position and [[:depth, :asc], [:position, :asc]] to avoid Mongo::OperationFailure: too much data for sort() with no index
