### PR TITLE
fixed the error that was introduced with fix for #170

### DIFF
--- a/app/controllers/admin/api_contents_controller.rb
+++ b/app/controllers/admin/api_contents_controller.rb
@@ -1,7 +1,9 @@
+require 'sanitize'
 module Admin
   class ApiContentsController < ActionController::Base
 
     include Locomotive::Routing::SiteDispatcher
+    
 
     before_filter :require_site
 


### PR DESCRIPTION
Hello,

I've found that even though tests all pass, the real POST request to api fails with:
uninitialized constant Admin::ApiContentsController::Sanitize

I'm not sure why or what would be the best way to fix it, but just adding `require 'sanitize'` to app/admin/api_contents_controller.rb solved my issues. I've observed the same error in development and production.

I've been puzzled why it works in testing environment, but not in the others, but this helps
