### PR TITLE
Fixed issue with tablerow tag

### DIFF
--- a/features/engine/tablerow.feature
+++ b/features/engine/tablerow.feature
@@ -1,0 +1,42 @@
+Feature: TableRow liquid tags
+  As a designer
+  I want to be able to use the tablerow liquid tag with locomotive contents
+
+Background:
+  Given I have the site: "test site" set up
+  And I have a custom model named "Projects" with
+    | label         | kind      | required  |
+    | Name          | string    | true      |
+  And I have entries for "Projects" with
+    | name        |
+    | Project 1   |
+    | Project 2   |
+    | Project 3   |
+
+Scenario: Use the tablerow tag
+  Given a page named "project-table" with the template:
+    """
+    <h1>Projects</h1>
+    <table>
+    {% tablerow project in contents.projects cols: 2 %}
+    {{ project.name }}
+    {% endtablerow %}
+    </table>
+    """
+  When I view the rendered page at "/project-table"
+  Then the rendered output should look like:
+    """
+    <h1>Projects</h1>
+    <table>
+    <tr class="row1">
+    <td class="col1">
+    Project 1
+    </td><td class="col2">
+    Project 2
+    </td></tr>
+    <tr class="row2"><td class="col1">
+    Project 3
+    </td></tr>
+
+    </table>
+    """

--- a/lib/locomotive/liquid/drops/contents.rb
+++ b/lib/locomotive/liquid/drops/contents.rb
@@ -29,9 +29,15 @@ module Locomotive
           self.collection.each(&block)
         end
 
+        def each_with_index(&block)
+          self.collection.each_with_index(&block)
+        end
+
         def size
           self.collection.size
         end
+
+        alias :length :size
 
         def empty?
           self.collection.empty?

--- a/spec/lib/locomotive/liquid/drops/contents_spec.rb
+++ b/spec/lib/locomotive/liquid/drops/contents_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 describe Locomotive::Liquid::Drops::Contents do
 
   before(:each) do
+    # Reload the file (needed for spork)
+    load File.join(Rails.root, 'lib', 'locomotive', 'liquid', 'drops', 'contents.rb')
+
     @site = Factory.build(:site)
     @content_type = Factory.build(:content_type, :site => @site, :slug => 'projects')
   end
@@ -22,12 +25,39 @@ describe Locomotive::Liquid::Drops::Contents do
 
   end
 
+  describe Locomotive::Liquid::Drops::ProxyCollection do
+
+    before(:each) do
+      populate_content_type
+      @proxy_collection = Locomotive::Liquid::Drops::ProxyCollection.new(@content_type)
+      @proxy_collection.context = {}
+    end
+
+    it 'provides its size like an Array' do
+      @proxy_collection.size.should == @proxy_collection.length
+    end
+
+    it 'can be enumerated using each_with_index' do
+      @proxy_collection.each_with_index do |item, index|
+        item._slug.should == "item#{index + 1}"
+      end
+    end
+
+  end
+
   def render_template(template = '', assigns = {})
     assigns = {
       'contents' => Locomotive::Liquid::Drops::Contents.new
     }.merge(assigns)
 
     Liquid::Template.parse(template).render(::Liquid::Context.new({}, assigns, { :site => @site }))
+  end
+
+  def populate_content_type
+    @content_type.order_by = :_slug
+    @content_type.contents.build(:_slug => 'item1')
+    @content_type.contents.build(:_slug => 'item2')
+    @content_type.contents.build(:_slug => 'item3')
   end
 
 end


### PR DESCRIPTION
Added a few missing methods to the ProxyCollection class used by the contents liquid drop in order to make the liquid tablerow tag work (http://wiki.shopify.com/UsingLiquid#Tables)
