### PR TITLE
Issue #176 Fix: Do not render twice for cached pages.

### DIFF
--- a/lib/locomotive/render.rb
+++ b/lib/locomotive/render.rb
@@ -103,7 +103,7 @@ module Locomotive
           end
         end
 
-        render :text => output, :layout => false, :status => page_status
+        render :text => output, :layout => false, :status => page_status unless performed?
       end
 
       def not_found_page


### PR DESCRIPTION
line 99 on the render.rb will render a 'not modified' if the page is 'fresh'. This causes another render to happen when the render line below runs.

https://github.com/locomotivecms/engine/blob/master/lib/locomotive/render.rb#L99

I've just added a conditional to not render if a render has already occurred. I couldn't write a failing test for this after spending a decent amount of time on this, but I can simulate it in the browser and it seems good with the fix.
