### PR TITLE
IE workaround for some broken select boxes

### DIFF
--- a/public/javascripts/admin/custom_fields/has_many.js
+++ b/public/javascripts/admin/custom_fields/has_many.js
@@ -11,10 +11,10 @@ $(document).ready(function() {
 
       if (context.data.new_item) {
         var newItemInfo = context.data.new_item;
-        var option = new Option(newItemInfo.label, newItemInfo.url, true, true);
+        var option = makeOption(newItemInfo.label, newItemInfo.url, true, true);
         context.select.append(option);
 
-        context.select.append(new Option('-'.repeat(newItemInfo.label.length), '', false, false));
+        context.select.append(makeOption('-'.repeat(newItemInfo.label.length), '', false, false));
       }
 
       for (var i = 0; i < context.data.collection.length; i++) {
@@ -27,7 +27,7 @@ $(document).ready(function() {
           for (var j = 0; j < obj.items.length; j++) {
             var innerObj = obj.items[j];
             if ($.inArray(innerObj[1], context.data.taken_ids) == -1) {
-              optgroup.append(new Option(innerObj[0], innerObj[1], false, false));
+              optgroup.append(makeOption(innerObj[0], innerObj[1], false, false));
               size++;
             }
           }
@@ -36,8 +36,7 @@ $(document).ready(function() {
         } else {
           if ($.inArray(obj[1], context.data.taken_ids) == -1)
           {
-            var option = new Option("", obj[1], false, false);
-            $(option).text(obj[0]);
+            var option = makeOption(obj[0], obj[1], false, false);
             context.select.append(option);
           }
         }

--- a/public/javascripts/admin/utils.js
+++ b/public/javascripts/admin/utils.js
@@ -31,3 +31,10 @@ Object.size = function(obj) {
   }
   return size;
 };
+
+// Make a DOM option for a select box. This code works around a bug in IE
+function makeOption(text, value, defaultSelected, selected) {
+  var option = new Option('', value, defaultSelected, selected);
+  $(option).text(text);
+  return option;
+}


### PR DESCRIPTION
Hey guys,

IE wasn't displaying some options in some dynamically populated select boxes. It appears that the implementation of the "new Option(text, value, defaultSelected, selected)" constructor is broken in IE. It doesn't actually set the text. This is in IE 8, I haven't tested any other versions. It looks like a workaround is to set the text using JQuery. I applied that workaround to fix the issues that I was seeing. It may not be the most elegant solution, but it appears to work.

Alex S.
