### PR TITLE
should sort by Page#depth so slug parts are in the right order

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -69,7 +69,7 @@ class Page
     if self.index? || self.not_found?
       self.slug
     else
-      slugs = self.self_and_ancestors.map(&:slug)
+      slugs = self.self_and_ancestors.sort_by(&:depth).map(&:slug)
       slugs.shift unless slugs.size == 1
       File.join slugs
     end


### PR DESCRIPTION
Tiny patch for "namespaced" pages
