### PR TITLE
Added .htc file content type to white list

### DIFF
--- a/app/uploaders/theme_asset_uploader.rb
+++ b/app/uploaders/theme_asset_uploader.rb
@@ -9,7 +9,7 @@ class ThemeAssetUploader < CarrierWave::Uploader::Base
   end
 
   def extension_white_list
-    %w(jpg jpeg gif png css js swf flv eot svg ttf woff otf ico)
+    %w(jpg jpeg gif png css js swf flv eot svg ttf woff otf ico htc)
   end
 
   def self.url_for(site, path)

--- a/lib/locomotive/carrierwave/asset.rb
+++ b/lib/locomotive/carrierwave/asset.rb
@@ -21,7 +21,7 @@ module Locomotive
               :media      => [/^video/, 'application/x-shockwave-flash', 'application/x-swf', /^audio/, 'application/ogg', 'application/x-mp3'],
               :pdf        => ['application/pdf', 'application/x-pdf'],
               :stylesheet => ['text/css'],
-              :javascript => ['text/javascript', 'text/js', 'application/x-javascript', 'application/javascript'],
+              :javascript => ['text/javascript', 'text/js', 'application/x-javascript', 'application/javascript', 'text/x-component'],
               :font       => ['application/x-font-ttf', 'application/vnd.ms-fontobject', 'image/svg+xml', 'application/x-woff']
             }
           end


### PR DESCRIPTION
To allow use for css3pie. It needs to be on the same domain as the website due to crossdomain restrictions in Internet Explorer.
