### PR TITLE
Liquid syntax mistake

### DIFF
--- a/config/locales/default.ru.yml
+++ b/config/locales/default.ru.yml
@@ -29,7 +29,7 @@ ru:
           title: "Страница не найдена"
           body: "Содержимое страницы 404"
         other:
-          body: "{% расширяет 'parent' %}"
+          body: "{% extends 'parent' %}"
 
   mongoid:
     attributes:


### PR DESCRIPTION
It seems that I translated completely all strings even if they didn't require translation =)))
