### PR TITLE
Rails 3.1 is getting used as a dependency when installing as a gem

### DIFF
--- a/locomotive_cms.gemspec
+++ b/locomotive_cms.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'nowarning'
 
-  s.add_dependency 'rails', '>= 3.0.10'
+  s.add_dependency 'rails', '~> 3.0.10'
   s.add_dependency 'warden'
   s.add_dependency 'devise', '1.3.4'
   s.add_dependency 'devise_bushido_authenticatable', '1.0.0.alpha10'


### PR DESCRIPTION
The `locomotive.gemspec` defines the rails dependency using `>= 3.0.10`. This is causing rails 3.1 to be used. However the `Gemfile` is targeting `3.0.10`.

This commit changes the `locomotive.gemspec` to pull in rails using `~> 3.0.10`, but it should probably use the same notation that is used in the Gemfile.
