### PR TITLE
Method missing "disable_parent_editable_elements" for nil

### DIFF
--- a/lib/locomotive/liquid/tags/inherited_block.rb
+++ b/lib/locomotive/liquid/tags/inherited_block.rb
@@ -7,7 +7,7 @@ module Locomotive
           super
           
           if !self.contains_super?(@nodelist) # then disable all editable_elements coming from the parent block too and not used
-            @context[:page].disable_parent_editable_elements(@name)
+            @context[:page].disable_parent_editable_elements(@name) unless @context[:page].nil?
           end
         end
 


### PR DESCRIPTION
Using block and editable_elements in snippet, sometimes you can have this error message:
Method missing "disable_parent_editable_elements" for nil

This commit fix this bug.
