### PR TITLE
added published? and listed? methods for Page drop

### DIFF
--- a/lib/locomotive/liquid/drops/page.rb
+++ b/lib/locomotive/liquid/drops/page.rb
@@ -32,6 +32,14 @@ module Locomotive
         def depth
           self._source.depth
         end
+        
+        def listed?
+          self._source.listed?
+        end
+        
+        def published?
+          self._source.published?
+        end
 
       end
     end

--- a/spec/lib/locomotive/liquid/drops/page_spec.rb
+++ b/spec/lib/locomotive/liquid/drops/page_spec.rb
@@ -79,6 +79,16 @@ describe Locomotive::Liquid::Drops::Page do
     end
 
   end
+  
+  describe 'published?' do
+    subject { render_template('{{ home.published? }}') }
+    it { should == @home.published?.to_s }
+  end
+  
+  describe 'listed?' do
+    subject { render_template('{{ home.listed? }}') }
+    it { should == @home.listed?.to_s }
+  end
 
   describe 'meta_keywords' do
     subject { render_template('{{ home.meta_keywords }}') }


### PR DESCRIPTION
Hello,

I've found that this is really missing when tried to build a menu without the 'nav' tag cause the markup could not be fitted into it's requirements. Believe this should be useful to more people doing anything with pages
