### PR TITLE
Fix a before_filter preventing to save a content instance with a

### DIFF
--- a/app/models/content_instance.rb
+++ b/app/models/content_instance.rb
@@ -104,6 +104,7 @@ class ContentInstance
   def set_visibility
     field = self.content_type.content_custom_fields.detect { |f| %w{visible active}.include?(f._alias) }
     self._visible = self.send(field._name) rescue true
+    true
   end
 
   def add_to_list_bottom


### PR DESCRIPTION
custom field `active' or`visible' set to false.
Fixes #272.
