### PR TITLE
Added ru locale to inline_editor

### DIFF
--- a/public/javascripts/admin/inline_editor_toolbar.js
+++ b/public/javascripts/admin/inline_editor_toolbar.js
@@ -196,6 +196,14 @@ var InlineEditorToolbar = {
       'cancel': 'annulla',
       'back': 'fine modifica',
       'saving': 'sto salvando'
-    }
+    },
+	'ru': {
+      'home': 'панель управления',
+      'edit': 'редактирование',
+      'save': 'сохранение',
+      'cancel': 'отмена',
+      'back': 'закончить редактирование',
+      'saving': 'сохранение'	
+	}
   }
 };


### PR DESCRIPTION
Added russian locale to inline_editor. Locomotive cms have russian location in admin, but haven't in inline_editor, so when russian locale is on and inline_editor enable to page, js crushes and block all js in the page
