### PR TITLE
De locales 2.0

### DIFF
--- a/config/locales/admin_ui.de.yml
+++ b/config/locales/admin_ui.de.yml
@@ -40,6 +40,10 @@ de:
         site: Mandant
         theme_assets: Dateien
         bookings: Buchungen
+      form:
+        change_file: Ändern
+        delete_file: Löschen
+        cancel: Abbrechen
       footer:
         who_is_behind: "Dienst entwickelt von %{development} und entworfen von <a href=\"http://www.sachagreif.com\">Sacha Greif</a>"
       form_actions:


### PR DESCRIPTION
Added a few locales for german. (2.0.0.rc)

During the next weeks i'll do a complete review for the german translations.

1) We need the polite form when addressing users:
http://german.about.com/od/grammar/a/Germanyou.htm

2) Some hints/descriptions are outdated.
