### PR TITLE
Corrected Spanish misspelling: Setiembre -> Septiembre

### DIFF
--- a/config/locales/default.es.yml
+++ b/config/locales/default.es.yml
@@ -117,8 +117,8 @@ es:
 
     day_names: [Domingo, Lunes, Martes, Miércoles, Jueves, Viernes, Sábado]
     abbr_day_names: [Dom, Lun, Mar, Mie, Jue, Vie, Sab]
-    month_names: [~, Enero, Febrero, Marzo, Abril, Mayo, Junio, Julio, Agosto, Setiembre, Octubre, Noviembre, Diciembre]
-    abbr_month_names: [~, Ene, Feb, Mar, Abr, May, Jun, Jul, Ago, Set, Oct, Nov, Dic]
+    month_names: [~, Enero, Febrero, Marzo, Abril, Mayo, Junio, Julio, Agosto, Septiembre, Octubre, Noviembre, Diciembre]
+    abbr_month_names: [~, Ene, Feb, Mar, Abr, May, Jun, Jul, Ago, Sep, Oct, Nov, Dic]
     order: [ year, month, day ]
 
   time:


### PR DESCRIPTION
Hi there,

Just a small typo fix; in Spanish, September is called "Septiembre", not "Setiembre". This should be mergeable with both master and 2.0.0.rc1
