### PR TITLE
added a snippet option to the liquid nav tag 

### DIFF
--- a/app/models/locomotive/extensions/page/tree.rb
+++ b/app/models/locomotive/extensions/page/tree.rb
@@ -78,8 +78,8 @@ module Locomotive
         #
         # @return [ Array ] The children pages ordered by their position
         #
-        def children_with_minimal_attributes
-          self.children.minimal_attributes
+        def children_with_minimal_attributes( attrs = [] )
+          self.children.minimal_attributes( attrs )
         end
 
         # Assigns the new position of each child of this node.

--- a/app/models/locomotive/page.rb
+++ b/app/models/locomotive/page.rb
@@ -51,7 +51,7 @@ module Locomotive
     scope :published,           :where => { :published => true }
     scope :fullpath,            lambda { |fullpath| { :where => { :fullpath => fullpath } } }
     scope :handle,              lambda { |handle| { :where => { :handle => handle } } }
-    scope :minimal_attributes,  :only => %w(title slug fullpath position depth published templatized redirect listed parent_id created_at updated_at)
+    scope :minimal_attributes,  lambda { |attrs=[]| {:only => attrs + %w(title slug fullpath position depth published templatized redirect listed parent_id created_at updated_at) } }
 
     ## methods ##
 

--- a/lib/locomotive/liquid/drops/page.rb
+++ b/lib/locomotive/liquid/drops/page.rb
@@ -41,6 +41,10 @@ module Locomotive
           self._source.published?
         end
 
+        def before_method(meth)
+          self._source.editable_elements.where(:slug => meth).try(:first).try(:content)
+        end
+
       end
     end
   end

--- a/spec/lib/locomotive/liquid/drops/page_spec.rb
+++ b/spec/lib/locomotive/liquid/drops/page_spec.rb
@@ -81,6 +81,21 @@ describe Locomotive::Liquid::Drops::Page do
 
   end
 
+  context '#rendering page with editable_elements' do
+
+    before(:each) do
+      @site = FactoryGirl.create(:site)
+      @home = @site.pages.root.first
+      @home.update_attributes :raw_template => "{% block body %}{% editable_short_text 'body' %}Lorem ipsum{% endeditable_short_text %}{% endblock %}"
+      @home.editable_elements.first.content = 'Lorem ipsum'
+    end
+
+    it 'renders the text of the editable field' do
+      render_template('{{ home.body }}').should == 'Lorem ipsum'
+    end
+
+  end
+
   describe 'published?' do
     subject { render_template('{{ home.published? }}') }
     it { should == @home.published?.to_s }

--- a/spec/lib/locomotive/liquid/tags/nav_spec.rb
+++ b/spec/lib/locomotive/liquid/tags/nav_spec.rb
@@ -96,6 +96,10 @@ describe Locomotive::Liquid::Tags::Nav do
       render_nav('site', {}, 'icon: after').should match /<li id="child-1-link" class="link first"><a href="\/child_1">Child #1<span><\/span><\/a><\/li>/
     end
 
+    it 'renders a snippet for the title' do
+      render_nav('site', {}, 'snippet: "-{{page.title}}-"').should match /<li id="child-1-link" class="link first"><a href="\/child_1">-Child #1-<\/a><\/li>/
+    end
+
     it 'assigns a different dom id' do
       render_nav('site', {}, 'id: "main-nav"').should match /<ul id="main-nav">/
     end


### PR DESCRIPTION
this is useful if you want to render more than
just a page.title string within the nav list item.
(page.menueimage, page.menueteaser...)

use nav snippet: "<liquid snippet>" to provide a string
or nav snippet: "<snippetname>" to load the snippet from db.
added page.<editable_field> too for usage within liquid templates.

test included

---8<--- Example:

snippet: menuecontent

```
<img src="{{ page.menueimage | resize: '40x04#' }}" style="float:right"/> 
{{ page.title }}
<br/>
{{ page.menueteaser }}
```

nav tag in page:

```
{% nav site, exclude: '\.*\-bottom', depth: 2, snippet: menuecontent %} 
<div style="display:none">
{% block menuecontent %} 
{% editable_short_text 'menueteaser' %}{% endeditable_short_text %} 
{% editable_file 'menueimage' %}{% endeditable_file %}   
{% endblock %}
</div>
```

now an author is able to upload menueimages and write menueteasers
within the page itself
