### PR TITLE
Fix #329 : live editor iFrame hide page content

### DIFF
--- a/app/assets/stylesheets/locomotive/inline_editor/layout.css.scss
+++ b/app/assets/stylesheets/locomotive/inline_editor/layout.css.scss
@@ -11,6 +11,7 @@ body {
     width: 100%;
     height: 100%;
     display: block;
+    min-height: 1000px;
   }
 }
 


### PR DESCRIPTION
adding min-height: 1000px to #page iframe in app/assets/stylesheets/locomotive/inline_editor/layout.css.scss
