### PR TITLE
Added therubyracer gem for Linux

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ group :development do
   gem 'rspec-rails', '~> 2.8.0' # In order to have rspec tasks and generators
   gem 'rspec-cells'
 
+  gem 'therubyracer', '>= 0.8.2'
+
   gem 'unicorn' # Using unicorn_rails instead of webrick (default server)
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
     kgio (2.7.4)
     launchy (2.1.0)
       addressable (~> 2.2.6)
+    libv8 (3.3.10.4)
     locomotive-aloha-rails (0.20.1.1)
       actionpack (~> 3.2.1)
     locomotive-mongoid-tree (0.6.2)
@@ -299,6 +300,8 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     term-ansicolor (1.0.7)
+    therubyracer (0.9.10)
+      libv8 (~> 3.3.10)
     thor (0.14.6)
     tilt (1.3.3)
     treetop (1.4.10)
@@ -338,6 +341,7 @@ DEPENDENCIES
   rspec-rails (~> 2.8.0)
   sass-rails (~> 3.2.4)
   shoulda-matchers
+  therubyracer (>= 0.8.2)
   uglifier (~> 1.2.3)
   unicorn
   xpath (~> 0.1.4)


### PR DESCRIPTION
I tried to run Locomotive 2.0 on Ubuntu 10.10 and got [this](https://github.com/rails/coffee-rails/issues/23) exception. I added the gem and it runs now on Linux.
