### PR TITLE
Require the engine on gem load.

### DIFF
--- a/lib/locomotive_cms.rb
+++ b/lib/locomotive_cms.rb
@@ -1,0 +1,1 @@
+require 'locomotive/engine'


### PR DESCRIPTION
Removes the need to manually require the engine in the `Gemfile`. Anyone who does not want to automatically require the engine can add `require => false` to their Gemfile for locomotive.
