### PR TITLE
Inline editor bug in Firefox

### DIFF
--- a/app/assets/javascripts/locomotive/views/inline_editor/application_view.js.coffee
+++ b/app/assets/javascripts/locomotive/views/inline_editor/application_view.js.coffee
@@ -30,11 +30,11 @@ class Locomotive.Views.InlinEditor.ApplicationView extends Backbone.View
 
       if @_$('meta[name=inline-editor]').size() > 0
         # bind the resize event. When the iFrame's size changes, update its height
-        iframe_content = iframe.contents().find('body')
+        iframe_content = iframe.contents()
         iframe_content.resize ->
           elem = $(this)
 
-          if elem.outerHeight(true) > $('body').outerHeight(true) # Resize the iFrame.
+          if elem.outerHeight(true) > iframe.outerHeight(true) # Resize the iFrame.
             iframe.css height: elem.outerHeight(true)
 
         # Resize the iFrame immediately.


### PR DESCRIPTION
The iframe for the inline editor wasn't resizing correctly and was cutting of a bit on content in Firefox. This change made it work for me: instead of comparing the size of the body of the page inside the iframe to the body of the page containing the iframe, I'm comparing the size of the entire page inside the iframe to the size of the iframe itself. It still works in Safari and Chrome as well.
