### PR TITLE
Bug while sending notification email

### DIFF
--- a/app/models/locomotive/content_entry.rb
+++ b/app/models/locomotive/content_entry.rb
@@ -148,7 +148,7 @@ module Locomotive
       self.site.accounts.each do |account|
         next unless self.content_type.public_submission_accounts.map(&:to_s).include?(account._id.to_s)
 
-        Locomotive::Notifications.new_content_entry(account, self).deliver
+        Locomotive::Notifications.new_content_entry(self, account).deliver
       end
     end
 


### PR DESCRIPTION
There is a bug while sending notification email on successfully submission public avaliable record.

> NoMethodError (undefined method `content_type' for #<Locomotive::Account:0x00000006a52cf0>):
>  mongoid (2.4.8) lib/mongoid/attributes.rb:166:in`method_missing'
>  .../shared/bundle/ruby/1.9.1/bundler/gems/engine-f7388d14e709/app/mailers/locomotive/notifications.rb:7:in `new_content_entry'
>  actionpack (3.2.3) lib/abstract_controller/base.rb:167:in`process_action'
>  actionpack (3.2.3) lib/abstract_controller/base.rb:121:in `process'
>  actionpack (3.2.3) lib/abstract_controller/rendering.rb:45:in`process'
>  actionmailer (3.2.3) lib/action_mailer/base.rb:456:in `process'
>  actionmailer (3.2.3) lib/action_mailer/base.rb:451:in`initialize'
>  actionmailer (3.2.3) lib/action_mailer/base.rb:438:in `new'
>  actionmailer (3.2.3) lib/action_mailer/base.rb:438:in`method_missing'
>  .../shared/bundle/ruby/1.9.1/bundler/gems/engine-f7388d14e709/app/models/locomotive/content_entry.rb:151:in `block in send_notifications'
>  mongoid (2.4.8) lib/mongoid/contexts/mongo.rb:260:in`block (2 levels) in iterate'
>  mongoid (2.4.8) lib/mongoid/cursor.rb:50:in `block in each'
>  mongoid (2.4.8) lib/mongoid/collections/retry.rb:29:in`retry_on_connection_failure'
>  mongoid (2.4.8) lib/mongoid/cursor.rb:48:in `each'
>  mongoid (2.4.8) lib/mongoid/contexts/mongo.rb:260:in`block in iterate'
>  mongoid (2.4.8) lib/mongoid/contexts/mongo.rb:478:in `selecting'
>  mongoid (2.4.8) lib/mongoid/contexts/mongo.rb:257:in`iterate'
>  mongoid (2.4.8) lib/mongoid/criteria.rb:145:in `block in each'
>  mongoid (2.4.8) lib/mongoid/criteria.rb:145:in`tap'
>  mongoid (2.4.8) lib/mongoid/criteria.rb:145:in `each'
>  .../shared/bundle/ruby/1.9.1/bundler/gems/engine-f7388d14e709/app/models/locomotive/content_entry.rb:148:in`send_notifications'
