### PR TITLE
Fixed typo for bootstrap setting: `data-toogle` to `data-toggle`

### DIFF
--- a/lib/locomotive/liquid/tags/nav.rb
+++ b/lib/locomotive/liquid/tags/nav.rb
@@ -95,7 +95,7 @@ module Locomotive
 
           if render_children_for_page?(page, depth) && bootstrap?
             css           += ' dropdown'
-            link_options  = %{ class="dropdown-toggle" data-toogle="dropdown"}
+            link_options  = %{ class="dropdown-toggle" data-toggle="dropdown"}
             href          = '#'
             caret         = %{ <b class="caret"></b>}
           end


### PR DESCRIPTION
After hours of head banging...
