### PR TITLE
Pagination sort

### DIFF
--- a/lib/locomotive/liquid/tags/paginate.rb
+++ b/lib/locomotive/liquid/tags/paginate.rb
@@ -12,7 +12,23 @@ module Locomotive
       #   {% for project in paginate.collection %}
       #     {{ project.name }}
       #   {% endfor %}
-      #  {% endpaginate %}
+      # {% endpaginate %}
+      #
+      # You can also specify an order for the collection items
+      #
+      # {% paginate contents.projects by 5 order: ascending %}
+      #   {% for project in paginate.collection %}
+      #     {{ project.name }}
+      #   {% endfor %}
+      # {% endpaginate %}
+      #
+      # You can also specify which attribute to sort by.
+      # {% paginate contents.projects by 5 sort_by: name order: ascending %}
+      #   {% for project in paginate.collection %}
+      #     {{ project.name }}
+      #   {% endfor %}
+      # {% endpaginate %}
+      #
       #
 
       class Paginate < ::Liquid::Block


### PR DESCRIPTION
We added a sort feature for the 'pagination' tag based on the sort feature present in the main shopify/liquid repo for 'for' tags. 

The logic is more-or-less identical to the aforementioned sort feature, with the addition of allowing options for pagination tags in the initialization. The syntax for adding options was borrowed directly from other tags in the locomotive/engine repo that allow options.

The syntax is fairly straight-forward and also listed as part of the comments in paginate.rb.

Example:

{% paginate post.tags sort_by name order: descending %}
    {{ tag.name }}
{% endfor %}

We believe this feature adds little complexity while creating much more flexibility for users hoping to do custom sorting.
