### PR TITLE
Fixed issue with page drop slug on templatized pages

### DIFF
--- a/lib/locomotive/liquid/drops/page.rb
+++ b/lib/locomotive/liquid/drops/page.rb
@@ -10,7 +10,7 @@ module Locomotive
         end
 
         def slug
-          self._source.templatized? ? self._source.content_type.slug.singularize : self._source.slug
+          self._source.templatized? ? @context['entry']._slug.singularize : self._source.slug
         end
 
         def parent

--- a/spec/lib/locomotive/liquid/drops/page_spec.rb
+++ b/spec/lib/locomotive/liquid/drops/page_spec.rb
@@ -81,6 +81,22 @@ describe Locomotive::Liquid::Drops::Page do
 
   end
 
+  context '#rendering page slug' do
+
+    it 'renders the slug of a normal page' do
+      render_template('{{ home.slug }}').should == 'index'
+    end
+
+    it 'renders the content instance slug instead for a templatized page' do
+      templatized = FactoryGirl.build(:page, :title => 'Lorem ipsum template', :templatized => true)
+
+      entry = Locomotive::Liquid::Drops::ContentEntry.new(mock('entry', :_slug => 'my_entry'))
+
+      render_template('{{ page.slug }}', 'page' => templatized, 'entry' => entry).should == 'my_entry'
+    end
+
+  end
+
   context '#rendering page with editable_elements' do
 
     before(:each) do


### PR DESCRIPTION
The page drop's `slug` method was broken for templatized pages. The `Page` model doesn't have the `content_type` method anymore, so I changed it to use `@context['entry']` instead, similar to the `title` method for the page drop.
