### PR TITLE
Added fix for CTRL+S in string fields - bind keyup to model.set

### DIFF
--- a/app/assets/javascripts/locomotive/views/content_entries/_form_view.js.coffee
+++ b/app/assets/javascripts/locomotive/views/content_entries/_form_view.js.coffee
@@ -43,7 +43,6 @@ class Locomotive.Views.ContentEntries.FormView extends Locomotive.Views.Shared.F
 
   bind_keyup_in_text_fields: ->
     _.each @$('li.input.stringish input[type=text]'), (textfield) =>
-      alert
       $(textfield).bind 'keyup', (event) =>
         input = $(event.target)
         input_name = input[0].name.match(/\w*\[(\w*)\]/)[1]


### PR DESCRIPTION
Fix for "Ctrl+S" saving when you are editing a "stringish" text input in a content entry.
For example, if you changed something in a "simple input" field, and pressed CTRL+S without changing focus from that field, it wouldn't send the new contents of that field over AJAX. now it does.

This fixes for "Simple Input" fields, as well as SEO Title & meta data fields, etc.
