### PR TITLE
Don't highlight background color for liquid tags

### DIFF
--- a/vendor/assets/stylesheets/locomotive/liquid_mode.css
+++ b/vendor/assets/stylesheets/locomotive/liquid_mode.css
@@ -1,9 +1,7 @@
 .cm-liquid-tag {
-  color: #32273f;
-  background: #ead9ff;
+  color: #660066;
 }
 
 .cm-liquid-variable {
-  color: #29739b;
-  background: #c2e0f0;
+  color: #009999;
 }


### PR DESCRIPTION
When you type liquid tags in the admin's editor it changes background color. And when you select region by mouse text is not highlights. So I see the solution to don't change background for liquid tags.

This was before: http://www.evernote.com/shard/s135/sh/4e463de7-38a4-44fd-86b3-a7051438dcf3/1fd67189da81a278acc91caaf83b9d02

And now: http://www.evernote.com/shard/s135/sh/8bd08f83-a948-48df-a9e4-cd58272a8122/79fa5f3311bb8d07e42b7fe2f0f23bba
