### PR TITLE
Enables group_by_<belongs_to field> in liquid

### DIFF
--- a/app/models/locomotive/content_type.rb
+++ b/app/models/locomotive/content_type.rb
@@ -121,9 +121,7 @@ module Locomotive
       self.to_presenter.as_json
     end
 
-    protected
-
-    def group_by_belongs_to_field(field)
+     def group_by_belongs_to_field(field)
       grouped_entries     = self.ordered_entries.group_by(&:"#{field.name}_id")
       columns             = grouped_entries.keys
       target_content_type = self.class_name_to_content_type(field.class_name)
@@ -131,19 +129,22 @@ module Locomotive
 
       all_columns.map do |column|
         if columns.include?(column._id)
-          {
+          HashWithIndifferentAccess.new ({
             :name     => column._label(target_content_type),
             :entries  => grouped_entries.delete(column._id)
-          }
+          } )
         else
           nil
         end
       end.compact.tap do |groups|
         unless grouped_entries.empty? # "orphans" ?
-          groups << { :name => nil, :entries => grouped_entries.values.flatten }
+          groups << HashWithIndifferentAccess.new( { :name => nil, :entries => grouped_entries.values.flatten } )
         end
       end
     end
+
+    protected
+   
 
     def order_by_attribute
       return self.order_by if %w(created_at updated_at _position).include?(self.order_by)

--- a/lib/locomotive/liquid/drops/content_types.rb
+++ b/lib/locomotive/liquid/drops/content_types.rb
@@ -28,9 +28,14 @@ module Locomotive
 
         def before_method(meth)
           klass = @content_type.entries.klass # delegate to the proxy class
-
           if (meth.to_s =~ /^group_by_(.+)$/) == 0
-            klass.send(:group_by_select_option, $1, @content_type.order_by_definition)
+            field = @content_type.entries_custom_fields.detect{|x| x.name==$1}
+            case (field.nil? ? nil : field['type'])
+            when 'belongs_to'
+              @content_type.group_by_belongs_to_field(field)
+            else
+              klass.send(:group_by_select_option, $1, @content_type.order_by_definition)
+            end
           else
             Locomotive.log :warn, "[Liquid template] trying to call #{meth} on a content_type object"
           end


### PR DESCRIPTION
This allows you to do a "group by" in liquid for a "belongs to" field.

For Example: if you have models "Movies" belongs to "Director", you can write code like this:

``` liquid
{%for group in contents.movies.group_by_director %}
{{group.name}}  has  {{group.entries.size}}  movies:
{%for movie in group.entries%}
{{movie.name}} -
{%endfor%}
<br>
{%endfor%}
```

to give something  like:

Hitchcock has 3 movies : Birds - Psycho - Rear Window -
Spielberg has 4 movies : ET - Raiders of the Lost Ark - Jaws - Saving Private Ryan -
