### PR TITLE
Fixed issue with removing membership from a site

### DIFF
--- a/app/assets/javascripts/locomotive/models/site.js.coffee
+++ b/app/assets/javascripts/locomotive/models/site.js.coffee
@@ -13,7 +13,8 @@ class Locomotive.Models.Site extends Backbone.Model
 
     @set domains: domains, memberships: memberships
 
-  includes_domain: (name) ->
+  includes_domain: (name_with_port) ->
+    name = name_with_port.replace(/:[0-9]*/, '')
     name == @domain_with_domain() || _.any(@get('domains'), (domain) -> domain.get('name') == name)
 
   domain_with_domain: ->

--- a/features/backoffice/site.feature
+++ b/features/backoffice/site.feature
@@ -31,3 +31,8 @@ Feature: Manage my site
   Scenario: Removing a domain from a site
     Given I am an authenticated user
     Then I should be able to remove a domain from my site
+
+  @javascript
+  Scenario: Removing a membership
+    Given I am an authenticated user
+    Then I should be able to remove a membership from my site

--- a/features/step_definitions/site_steps.rb
+++ b/features/step_definitions/site_steps.rb
@@ -57,3 +57,16 @@ Then /^I should be able to remove a domain from my site$/ do
   page.should have_content 'My site was successfully updated'
   @site.reload.domains_without_subdomain.should be_blank
 end
+
+Then /^I should be able to remove a membership from my site$/ do
+  @new_account = FactoryGirl.create(:author, :site => @site)
+  @site.save!
+
+  visit edit_current_site_path
+
+  click_link 'x'
+  click_button 'Save'
+
+  page.should have_content 'My site was successfully updated'
+  @site.reload.memberships.collect(&:account).should_not include(@new_account)
+end


### PR DESCRIPTION
I wasn't able to remove a membership from a site. This issue was posted before (#397) but wasn't reproducible. I discovered that it wasn't reproducible because it only failed when running the server on a port other than the default (port 80). The problem is twofold:
- The `app/assets/javascripts/locomotive/views/current_site/edit_view.js.coffee` file checks to see if the model's domains includes the current location. However, the current location string includes the port number and the model's domain does not. So as a result, it was trying to do a regular post rather than an AJAX post since the current location was "not included" in the model's domains list.
- The regular (non-AJAX) post seems to submit the form fields, rather than the backbone model attributes. This means that since the UI removes the deleted memberships from the DOM, the membership's "_destroy" attribute is not pushed. I can't say I know very much about backbone, but I think that a regular (non-AJAX) post should still try to sync using the backbone model, rather than the form fields.

I fixed the first issue, so now it uses AJAX requests for apps run on other ports. I also put a cucumber feature around it.
