### PR TITLE
With_scope attributes should be cloned when rendering - fix

### DIFF
--- a/lib/locomotive/liquid/tags/with_scope.rb
+++ b/lib/locomotive/liquid/tags/with_scope.rb
@@ -27,7 +27,7 @@ module Locomotive
 
         def render(context)
           context.stack do
-            context['with_scope'] = decode(@attributes, context)
+            context['with_scope'] = decode(@attributes.clone, context)
             render_all(@nodelist, context)
           end
         end

--- a/spec/lib/locomotive/liquid/tags/with_scope_spec.rb
+++ b/spec/lib/locomotive/liquid/tags/with_scope_spec.rb
@@ -35,5 +35,11 @@ describe Locomotive::Liquid::Tags::WithScope do
     text = template.render
     text.should == "true-foo"
   end
+  
+  it 'allows a variable condition inside a loop' do
+    template = ::Liquid::Template.parse("{%for i in (1..3)%}{% with_scope number: i %}{{ with_scope.number}}{% endwith_scope %}{%endfor%}")
+    text = template.render
+    text.should == "123"
+  end
 
 end


### PR DESCRIPTION
I found that using a With_scope tag inside a for loop gave incorrect results for iterations greater than 1. The reason was because the "attributes" hash was being modified during the render, because it was not being cloned before it was put through the "decode" method. This fix changes that, and adds a spec to test it.
