### PR TITLE
Generator > Carrierwave : put S3 bucket region in environment var instead of hardcoded

### DIFF
--- a/lib/generators/locomotive/install/templates/carrierwave.rb
+++ b/lib/generators/locomotive/install/templates/carrierwave.rb
@@ -15,7 +15,7 @@ CarrierWave.configure do |config|
       :provider                 => 'AWS',
       :aws_access_key_id        => ENV['S3_KEY_ID'],
       :aws_secret_access_key    => ENV['S3_SECRET_KEY'],
-      :region                   => 'us-east-1'
+      :region                   => ENV['S3_BUCKET_REGION']
     }
     config.fog_directory    = ENV['S3_BUCKET']
 


### PR DESCRIPTION
See the documentation pull request referring to this : https://github.com/gabrielnau/documentation/commit/ff14201825ffde0dd3afae56fca8395720bbb610
