### PR TITLE
Display custom labels in SELECT menus when creating a new content entry

### DIFF
--- a/app/helpers/locomotive/content_entries_helper.rb
+++ b/app/helpers/locomotive/content_entries_helper.rb
@@ -5,7 +5,7 @@ module Locomotive
       content_type = Locomotive::ContentType.class_name_to_content_type(class_name, current_site)
 
       if content_type
-        content_type.ordered_entries.map { |entry| [entry._label, entry._id] }
+        content_type.ordered_entries.map { |entry| [entry_label(content_type, entry), entry._id] }
       else
         [] # unknown content type
       end


### PR DESCRIPTION
Allow the custom label for a foreign model to be appear in the `SELECT` menu that lists the `belongs_to` options for a given content model's entry.

**Use case**

Suppose you have content type models  `Volume`, `Issue`, and `Article` — where an article belongs to an issue and an issue belongs to a volume.

Also suppose that the `Presentation > Item template` on `Issue` is set to:

```
Volume {{entry.volume.number}} Number {{entry.number}}
```

while the `Presentation > Label field` is set to the issue `number` field.

When creating a new entry for the `Article` model, you should see a drop-down `SELECT` menu to assign the article to an issue. What we want to see is a drop-down with items like the following.

```
Volume 1 Number 1
Volume 1 Number 2
Volume 2 Number 1
Volume 2 Number 2
```

However, currently what we see is just the following.

```
1
2
1
2
```

This pull request provides the desired behavior of showing the custom display name, instead of the default label field, for issues when assigning an article to an issue.
