### PR TITLE
allow consume url to come form variable

### DIFF
--- a/spec/lib/locomotive/liquid/tags/consume_spec.rb
+++ b/spec/lib/locomotive/liquid/tags/consume_spec.rb
@@ -19,7 +19,7 @@ describe Locomotive::Liquid::Tags::Consume do
     end
 
     it 'raises an error if the syntax is incorrect' do
-      markup = 'blog from http://www.locomotiveapp.org'
+      markup = 'blog http://www.locomotiveapp.org'
       lambda do
         Locomotive::Liquid::Tags::Consume.new('consume', markup, ["{% endconsume %}"], {})
       end.should raise_error
@@ -34,6 +34,13 @@ describe Locomotive::Liquid::Tags::Consume do
       Locomotive::Httparty::Webservice.stubs(:get).returns(response)
       template = "{% consume blog from \"http://blog.locomotiveapp.org/api/read\" %}{{ blog.title }}{% endconsume %}"
       Liquid::Template.parse(template).render.should == 'Locomotive rocks !'
+    end
+
+    it 'puts the response into the liquid variable using a url from a variable' do
+      response = mock('response', :code => 200, :underscore_keys => { 'title' => 'Locomotive rocks !' })
+      Locomotive::Httparty::Webservice.stubs(:get).returns(response)
+      template = "{% consume blog from url %}{{ blog.title }}{% endconsume %}"
+      Liquid::Template.parse(template).render('url' => "http://blog.locomotiveapp.org/api/read").should == 'Locomotive rocks !'
     end
 
   end


### PR DESCRIPTION
Allows you to use a variable to set the url for a consume tag.
