### PR TITLE
Offer choice of permanent (301) or temporary (302) redirects

### DIFF
--- a/app/assets/javascripts/locomotive/views/pages/_form_view.js.coffee
+++ b/app/assets/javascripts/locomotive/views/pages/_form_view.js.coffee
@@ -121,10 +121,10 @@ class Locomotive.Views.Pages.FormView extends Locomotive.Views.Shared.FormView
   enable_response_type_select: ->
     @$('li#page_response_type_input').change (event) =>
       if $(event.target).val() == 'text/html'
-        @$('li#page_redirect_input, li#page_redirect_url_input').show()
+        @$('li#page_redirect_input, li#page_redirect_url_input, li#page_redirect_type_input').show()
       else
         @model.set redirect: false
-        @$('li#page_redirect_input, li#page_redirect_url_input').hide()
+        @$('li#page_redirect_input, li#page_redirect_url_input, li#page_redirect_type_input').hide()
 
   enable_templatized_checkbox: ->
     @_enable_checkbox 'templatized',
@@ -140,9 +140,9 @@ class Locomotive.Views.Pages.FormView extends Locomotive.Views.Shared.FormView
     @_enable_checkbox 'redirect',
       features:     ['templatized', 'cache_strategy']
       on_callback:  =>
-        @$('li#page_redirect_url_input').show()
+        @$('li#page_redirect_url_input, li#page_redirect_type_input').show()
       off_callback: =>
-        @$('li#page_redirect_url_input').hide()
+        @$('li#page_redirect_url_input, li#page_redirect_type_input').hide()
 
   enable_other_checkboxes: ->
     _.each ['published', 'listed'], (exp) =>

--- a/app/helpers/locomotive/pages_helper.rb
+++ b/app/helpers/locomotive/pages_helper.rb
@@ -59,6 +59,13 @@ module Locomotive
       ]
     end
 
+    def options_for_page_redirect_type
+      [
+        ['Permanent', 301],
+        ['Temporary', 302]
+      ]
+    end
+
     def page_response_type_to_string(page)
       options_for_page_response_type.detect { |t| t.last == page.response_type }.try(:first) || '&mdash;'
     end

--- a/app/models/locomotive/extensions/page/redirect.rb
+++ b/app/models/locomotive/extensions/page/redirect.rb
@@ -9,10 +9,12 @@ module Locomotive
 
           ## fields ##
           field :redirect,      :type => Boolean, :default => false
+          field :redirect_type, :type => Integer,  :default => 301
           field :redirect_url,  :type => String, :localize => true
 
           ## validations ##
-          validates_presence_of :redirect_url, :if => :redirect
+          validates_presence_of :redirect_type,  :if => :redirect
+          validates_presence_of :redirect_url,   :if => :redirect
           validates_format_of   :redirect_url, :with => Locomotive::Regexps::URL, :allow_blank => true
 
         end

--- a/app/presenters/locomotive/page_presenter.rb
+++ b/app/presenters/locomotive/page_presenter.rb
@@ -1,7 +1,7 @@
 module Locomotive
   class PagePresenter < BasePresenter
 
-    delegate :title, :slug, :fullpath, :handle, :position, :raw_template, :published, :listed, :templatized, :templatized_from_parent, :target_klass_slug, :redirect, :redirect_url, :template_changed, :cache_strategy, :response_type, :translated_in, :to => :source
+    delegate :title, :slug, :fullpath, :handle, :position, :raw_template, :published, :listed, :templatized, :templatized_from_parent, :target_klass_slug, :redirect, :redirect_type, :redirect_url, :template_changed, :cache_strategy, :response_type, :translated_in, :to => :source
 
     def escaped_raw_template
       h(self.source.raw_template)
@@ -12,7 +12,7 @@ module Locomotive
     end
 
     def included_methods
-      super + %w(title slug fullpath handle position raw_template published listed templatized templatized_from_parent target_klass_slug redirect redirect_url cache_strategy response_type template_changed editable_elements localized_fullpaths translated_in)
+      super + %w(title slug fullpath handle position raw_template published listed templatized templatized_from_parent target_klass_slug redirect redirect_type redirect_url cache_strategy response_type template_changed editable_elements localized_fullpaths translated_in)
     end
 
     def localized_fullpaths

--- a/app/views/locomotive/pages/_form.html.haml
+++ b/app/views/locomotive/pages/_form.html.haml
@@ -48,9 +48,11 @@
 
     = f.input :redirect, :as => :'Locomotive::Toggle', :wrapper_html => { :style => "#{'display: none' if @page.templatized? || !@page.default_response_type?}" }
 
-    = f.input :cache_strategy, :as => :select, :collection => options_for_page_cache_strategy, :include_blank => false, :wrapper_html => { :style => "#{'display: none' if @page.redirect?}" }
+    = f.input :redirect_type, :as => :select, :collection => options_for_page_redirect_type, :include_blank => false, :wrapper_html => { :style => "#{'display: none' unless @page.redirect?}" }
 
     = f.input :redirect_url, :required => true, :wrapper_html => { :style => "#{'display: none' unless @page.redirect?}" }
+
+    = f.input :cache_strategy, :as => :select, :collection => options_for_page_cache_strategy, :include_blank => false, :wrapper_html => { :style => "#{'display: none' if @page.redirect?}" }
 
   = f.inputs :name => :raw_template, :class => "inputs foldable #{'folded' if inputs_folded?(@page)}" do
 

--- a/lib/locomotive/render.rb
+++ b/lib/locomotive/render.rb
@@ -14,7 +14,7 @@ module Locomotive
       else
         @page = locomotive_page
 
-        redirect_to(@page.redirect_url, :status => 301) and return if @page.present? && @page.redirect?
+        redirect_to(@page.redirect_url, :status => @page.redirect_type) and return if @page.present? && @page.redirect?
 
         render_no_page_error and return if @page.nil?
 

--- a/spec/lib/locomotive/render_spec.rb
+++ b/spec/lib/locomotive/render_spec.rb
@@ -129,9 +129,12 @@ describe 'Locomotive rendering system' do
         @controller.current_site.pages.expects(:where).with(:depth => 1, :fullpath.in => %w{contact content_type_template}).returns([@page])
       end
 
-      it 'redirects to the redirect_url' do
-        @controller.expects(:redirect_to).with('http://www.example.com/', { :status => 301 }).returns(true)
-        @controller.send(:render_locomotive_page)
+      (301..302).each do |status|
+        it "redirects to the redirect_url with a #{status} status" do
+          @page.redirect_type = status
+          @controller.expects(:redirect_to).with('http://www.example.com/', { :status => status }).returns(true)
+          @controller.send(:render_locomotive_page)
+        end
       end
 
     end


### PR DESCRIPTION
The current page redirect only supports sending the 301 (permanent) header. Should your redirect be temporary, this has large SEO consequences since you are telling the search engines that there is no need to index the page that is redirecting.

This pull request creates a redirect type boolean that defaults to permanent but can be switched to temporary. Behind the scenes it sets whether to send a 301 or 302 header with the redirect.
