### PR TITLE
Open "Help" link on a new page

### DIFF
--- a/app/cells/locomotive/global_actions_cell.rb
+++ b/app/cells/locomotive/global_actions_cell.rb
@@ -24,7 +24,7 @@ module Locomotive
         add :switch, :url => '#', :id => 'sites-picker-link'
       end
 
-      add :help, :url => 'http://doc.locomotivecms.com/templates/basics', :class => 'tutorial', :id => 'help'
+      add :help, :url => 'http://doc.locomotivecms.com/templates/basics', :class => 'tutorial', :id => 'help', :target => '_blank'
       add :logout, :url => destroy_locomotive_session_url, :data => { :confirm => t('locomotive.messages.confirm') }, :method => :delete
     end
 


### PR DESCRIPTION
Small change, i think "Help" link on the backend should open on a new page.
