### PR TITLE
fix #463, file attachments breaking on models with text fields

### DIFF
--- a/app/assets/javascripts/locomotive/views/shared/fields/file_view.js.coffee
+++ b/app/assets/javascripts/locomotive/views/shared/fields/file_view.js.coffee
@@ -29,10 +29,10 @@ class Locomotive.Views.Shared.Fields.FileView extends Backbone.View
 
     # only in HTML 5
     @$('input[type=file]').bind 'change', (event) =>
-      input = $(event.target)[0]
+      input = event.target
 
       if input.files?
-        name  = $(input).attr('name')
+        name  = input.name
         hash  = {}
         hash[name.replace("#{@model.paramRoot}[", '').replace(/]$/, '')] = input.files[0]
         @model.set(hash)


### PR DESCRIPTION
This one should fix #463, verified on Chrome and Firefox.
