### PR TITLE
Gems update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
       multi_json (~> 1.3.4)
       net-scp (~> 1.1.0)
       rack-cache (~> 1.1)
-      rails (~> 3.2.11)
+      rails (~> 3.2.12)
       rails-backbone (~> 0.7.2)
       rake (~> 10.0.0)
       responders (~> 0.9.2)

--- a/locomotive_cms.gemspec
+++ b/locomotive_cms.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rake',                            '~> 10.0.0'
 
-  s.add_dependency 'rails',                           '~> 3.2.11'
+  s.add_dependency 'rails',                           '~> 3.2.12'
 
   s.add_dependency 'devise',                          '~> 2.2.3'
   s.add_dependency 'devise-encryptable',              '~> 0.1.1'


### PR DESCRIPTION
Due to recent gems update, current bundle (RC12) is not passing. Updated gems consequently :
- Rails : 3.2.12
- Devise : 2.3.3
- Net-scp : 1.1.0
- Heroku-API : 0.3.8
- Fog : 1.10.0

This pull request has to be linked with the one made on locomotive-heroku repository.
