### PR TITLE
Use compass-rails in dependencies.rb

### DIFF
--- a/lib/locomotive/dependencies.rb
+++ b/lib/locomotive/dependencies.rb
@@ -22,7 +22,7 @@ require 'cells'
 require 'sanitize'
 require 'stringex'
 
-require 'compass'
+require 'compass-rails'
 require 'codemirror/rails'
 require 'jquery/rails'
 require 'backbone-rails'


### PR DESCRIPTION
Plain compass broke the install process so changing it to compass-rails solved the step issue for me.
