### PR TITLE
fix issue #631

### DIFF
--- a/app/assets/javascripts/locomotive/views/application_view.js.coffee
+++ b/app/assets/javascripts/locomotive/views/application_view.js.coffee
@@ -80,7 +80,10 @@ class Locomotive.Views.ApplicationView extends Backbone.View
       picker.toggle()
 
     picker.find('li').bind 'click', (event) ->
-      locale = $(@).attr('data-locale')
+      # commented, jQuery was being funny with this one
+      # locale = $(@).attr('data-locale')
+      locale = $(@).data('locale')
+
       window.addParameterToURL 'content_locale', locale
 
   unique_dialog_zindex: ->


### PR DESCRIPTION
I just noticed when clicking a flag to translate a page the url was being wrongly composed.

instead of &content_locale=en it was passig and object, to the url.
