### PR TITLE
Add German locale to tinyMCE

### DIFF
--- a/app/assets/javascripts/tinymce/plugins/locomotive_media/langs/de.js
+++ b/app/assets/javascripts/tinymce/plugins/locomotive_media/langs/de.js
@@ -1,1 +1,1 @@
-tinyMCE.addI18n('en.locomotive_media',{"image_desc": "Medien einf&uuml;gen"});
+tinyMCE.addI18n('de.locomotive_media',{"image_desc": "Medien einfügen"});


### PR DESCRIPTION
Was missing in last version => long text editing not possible in German
