### PR TITLE
Fixed site save issue

### DIFF
--- a/app/assets/javascripts/locomotive/models/site.js.coffee
+++ b/app/assets/javascripts/locomotive/models/site.js.coffee
@@ -5,13 +5,11 @@ class Locomotive.Models.Site extends Backbone.Model
   urlRoot: "#{Locomotive.mounted_on}/sites"
 
   initialize: ->
-    # Be careful, domains_without_subdomain becomes domains
-    domains = _.map @get('domains_without_subdomain'), (name) =>
-      new Locomotive.Models.Domain(name: name)
+    @_fix_attributes()
 
-    memberships = new Locomotive.Models.MembershipsCollection(@get('memberships'))
-
-    @set domains: domains, memberships: memberships
+    # After save, need to fix the attributes again
+    this.on 'sync', ->
+      @_fix_attributes()
 
   includes_domain: (name_with_port) ->
     name = name_with_port.replace(/:[0-9]*/, '')
@@ -26,6 +24,16 @@ class Locomotive.Models.Site extends Backbone.Model
       hash.memberships_attributes = @get('memberships').toJSONForSave() if @get('memberships')? && @get('memberships').length > 0
       delete hash.domains
       hash.domains = _.map(@get('domains'), (domain) -> domain.get('name'))
+
+  _fix_attributes: ->
+    # Be careful, domains_without_subdomain becomes domains
+    domains = _.map @get('domains_without_subdomain'), (name) =>
+      new Locomotive.Models.Domain(name: name)
+
+    memberships = new Locomotive.Models.MembershipsCollection(@get('memberships'))
+
+    @set domains: domains, memberships: memberships
+
 
 class Locomotive.Models.CurrentSite extends Locomotive.Models.Site
 

--- a/features/backoffice/site.feature
+++ b/features/backoffice/site.feature
@@ -43,3 +43,12 @@ Feature: Manage my site
     Then I should be able to save the site with AJAX
     Given multi_sites is disabled
     Then I should be able to save the site with AJAX
+
+  @javascript
+  Scenario: Multiple saves
+    Given I am an authenticated user
+    When I go to the site settings
+    And I press "Save"
+    Then I should see "My site was successfully updated."
+    When I press "Save"
+    Then I should see "My site was successfully updated."


### PR DESCRIPTION
A javascript error would occur after clicking "Save" twice on the current_site/edit page. Wrapped this in a test and fixed the bug.
