### PR TITLE
Test on (more) current Rubinius 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ app/assets/stylesheets/old/
 .rbenv-gemsets
 .gitignore
 Gemfile.lock
+.rbx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_script: ./bin/ci/before_build.sh
 services: mongodb
 rvm:
   - 1.9.3
+  - rbx-nightly-19mode
 notifications:
   email:
     - didier@nocoffee.fr

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script: ./bin/ci/before_build.sh
 services: mongodb
 rvm:
   - 1.9.3
-  - rbx-nightly-19mode
+  - rbx-2
 notifications:
   email:
     - didier@nocoffee.fr


### PR DESCRIPTION
The specs pass on Rubinius in 1.9 mode except one:

<pre>
expected "Liquid error: method 'resize': given 1, expected 2" to include "Liquid error: wrong number of arguments"
</pre>


I would fix this if I knew a good way to do so. Basically, it's an implementation-specific error message. I think you may agree that Rubinius has a better message. :)

Anyway, would be awesome to have this rad project testing on Rubinius as well!
