### PR TITLE
Overwrites "j" method in order to strip out some unicode chars

### DIFF
--- a/app/helpers/locomotive/base_helper.rb
+++ b/app/helpers/locomotive/base_helper.rb
@@ -102,6 +102,12 @@ module Locomotive
       "Locomotive.Views.#{controller.controller_name.camelize}.#{action}View"
     end
 
+    # Remove some unicode chars from javascript output
+    # You might want to scape then instead?
+    def j(string)
+      super(string).gsub(/\u000d|\u0009|\u000c|\u0085|\u2028|\u2029/,"")
+    end
+    
     def backbone_view_data
       content_for?(:backbone_view_data) ? content_for(:backbone_view_data) : ''
     end


### PR DESCRIPTION
Here is a quick fix for JSON files breaking when printing some "pasted text" from some "weird document".

There's a lot of info about this issue here #693
