### PR TITLE
fix nokogiri 1.6 incompatibility issue, thanks @benjaminwood

### DIFF
--- a/locomotive_cms.gemspec
+++ b/locomotive_cms.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'responders',                      '~> 0.9.2'
   s.add_dependency 'cells',                           '~> 3.8.0'
   s.add_dependency 'RedCloth',                        '~> 4.2.8'
-  s.add_dependency 'sanitize',                        '~> 2.0.3'
+  s.add_dependency 'sanitize',                        '2.0.3'
   s.add_dependency 'highline',                        '~> 1.6.2'
   s.add_dependency 'stringex',                        '~> 1.5.1'
 


### PR DESCRIPTION
As reported by @benjaminwood in https://github.com/locomotivecms/engine/issues/721 the last sanitize version is not compatible with other gems of the engine anymore.

This is a very simple pull request to force sanitize version to 2.0.3, Waiting for other gem with nokogiri as a dependency to update to >=2.0.4
