### PR TITLE
Fixes rake dependency issue between Rails 3.2.13 and Locomotive 2.0.1

### DIFF
--- a/locomotive_cms.gemspec
+++ b/locomotive_cms.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.summary     = 'A Next Generation Sexy CMS for Rails 3'
   s.description = 'LocomotiveCMS is a next generation CMS system with sexy admin tools, liquid templating, and inline editing powered by mongodb and rails 3.2'
 
-  s.add_dependency 'rake',                            '~> 10.0.0'
+  s.add_dependency 'rake',                            '~> 10.0'
 
   s.add_dependency 'rails',                           '~> 3.2.13'
 


### PR DESCRIPTION
Rails (=3.2.13) depends on rake (10.1.0) while locomotive_cms (~> 2.0.1) ruby depends on rake (~> 10.0.0). Rake (~>10.0.0) is equivalent to (>=10.0.0) and (<10.1.0) making the gemspecs incompatible. I changed it to rake (~>10.0) to allow up to rake (<11.0). 
