### PR TITLE
Empty partial before Backbone init for extensions by main app

### DIFF
--- a/app/views/locomotive/shared/_head.html.haml
+++ b/app/views/locomotive/shared/_head.html.haml
@@ -14,6 +14,8 @@
 = stylesheet_link_tag     'locomotive', media: 'screen'
 = javascript_include_tag  'locomotive'
 
+= render 'locomotive/shared/main_app_head_before_backbone'
+
 %script{ type: 'text/javascript' }
   :plain
     window.locale                     = '#{I18n.locale}';

--- a/app/views/locomotive/shared/_main_app_head_before_backbone.html.haml
+++ b/app/views/locomotive/shared/_main_app_head_before_backbone.html.haml
@@ -1,0 +1,1 @@
+- # this partial can be overridden in the main app in order to include extra js before Backbone is initialized to include your own backbone Views/Models when extending the backoffice with your custom views.


### PR DESCRIPTION
To be able to extend the backoffice with custom views using Backbone views/models a hook is required to load main app JavaScript before Backbone is initialized.

The simplest solution I found is a second empty partial that can be overridden by the main app to load Backbone JS views or do whatever is required.
