### PR TITLE
fix text view to use tinymce serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ doc/dev.txt
 *.gem
 tmp/*
 .rvmrc
+.ruby-gemset
+.ruby-version
 Capfile
 config/deploy.rb
 perf/*.rb

--- a/app/assets/javascripts/locomotive/views/editable_elements/text_view.js.coffee
+++ b/app/assets/javascripts/locomotive/views/editable_elements/text_view.js.coffee
@@ -31,11 +31,11 @@ class Locomotive.Views.EditableElements.TextView extends Backbone.View
       height:   @model.get('rows') * @default_line_height
       oninit:   ((editor) =>
           $.cmd 'S', (() =>
-            @model.set(content: editor.getBody().innerHTML)
+            @model.set(content: editor.getContent())
             $(@el).parents('form').trigger('submit')
           ), [], ignoreCase: true, document: editor.dom.doc),
       onchange_callback: (editor) =>
-        @model.set(content: editor.getBody().innerHTML)
+        @model.set(content: editor.getContent())
 
   refresh: ->
     # do nothing


### PR DESCRIPTION
### Issue

When using a tinyMCE plugin that relies on a `parser`/`serializer` `NodeFilter` it would not work properly in a editable elements text view.
### Reason

`.getBody().innerHTML` is used instead of the proper tinyMCE API [`.getContent()`](http://www.tinymce.com/wiki.php/API3:method.tinymce.Editor.getContent) which would trigger the appropriate callbacks.
#### Side effects of `.getContent()`

Using `.getContent()` will encode umlaut and other utf8 things to HTML entities. Which already happens in `content_entries/form_view` (calls `.save()` which calls `.getContent()`) and is most likely the desired behaviour.
### Test

It would be relatively simple to test in a JS unit spec. My understanding is you do not have any JS unit specs? A cucumber feature seams wrong for this - up to you to decide if its worth testing.
