### PR TITLE
The API should return a proper content type when asking for entries

### DIFF
--- a/app/controllers/locomotive/api/content_entries_controller.rb
+++ b/app/controllers/locomotive/api/content_entries_controller.rb
@@ -4,13 +4,13 @@ module Locomotive
 
       load_and_authorize_resource({
         class:                Locomotive::ContentEntry,
-        through:              :content_type,
+        through:              :get_content_type,
         through_association:  :entries,
         find_by:              :find_by_id_or_permalink
       })
 
       def index
-        @content_entries = @content_entries.order_by([content_type.order_by_definition])
+        @content_entries = @content_entries.order_by([get_content_type.order_by_definition])
         respond_with @content_entries
       end
 
@@ -37,7 +37,7 @@ module Locomotive
 
       protected
 
-      def content_type
+      def get_content_type
         @content_type ||= current_site.content_types.where(slug: params[:slug]).first
       end
 

--- a/features/api/content_entries.feature
+++ b/features/api/content_entries.feature
@@ -80,6 +80,7 @@ Feature: Content Entries
       | 2/workers/1         | "w3"                          |
       | 2/client            | "c1"                          |
     And the JSON at "2/logo" should match /logo2.jpg$/
+    And the response content type should match /application\/json/
 
   Scenario: Updating existing project
     Given the JSON request at "content_entry/logo" is a file
@@ -111,6 +112,7 @@ Feature: Content Entries
       | 0/workers/1         | "w2"                          |
       | 0/client            | "c2"                          |
     And the JSON at "0/logo" should match /logo2.jpg$/
+    And the response content type should match /application\/json/
 
   # FIXME: (Did) What is the use case to modify the timestamps of a content entry
   @wip

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -1,4 +1,3 @@
-
 def api_base_url
   "http://#{Locomotive::Site.first.domains.first}/locomotive/api/"
 end
@@ -157,6 +156,10 @@ end
 
 Then /^the JSON at "([^"]*)" should match \/(.+)\/$/ do |path, regex|
   parse_json(last_json, path).should =~ /#{regex}/
+end
+
+Then /^the response content type should match \/(.+)\/$/ do |regex|
+  @json_response.header['Content-Type'].should =~ /#{regex}/
 end
 
 Then /^the JSON at "([^"]*)" should be the time "(.+)"$/ do |path, time_str|


### PR DESCRIPTION
I noticed that the API always returns the content type text/html, even though json or xml is requested. 

The reason for this was because the method content_type (which is a vanilla method in Rails controllers) was overloaded. I simply renamed it.
