### PR TITLE
Fix devise i18n key for views in local files

### DIFF
--- a/config/locales/devise.bg.yml
+++ b/config/locales/devise.bg.yml
@@ -45,7 +45,7 @@ en:
         unlock_instructions: 'Инструкции за отключване'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Здрасти

--- a/config/locales/devise.cs.yml
+++ b/config/locales/devise.cs.yml
@@ -45,7 +45,7 @@ cs:
         unlock_instructions: 'Intrukce k odemčení'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Ahoj

--- a/config/locales/devise.de.yml
+++ b/config/locales/devise.de.yml
@@ -44,7 +44,7 @@ de:
         unlock_instructions: 'Anleitung zur Entsperrung'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Hallo

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -45,7 +45,7 @@ en:
         unlock_instructions: 'Unlock Instructions'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Hello

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -45,7 +45,7 @@ es:
         unlock_instructions: 'Instrucciones de desbloqueo'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Hola

--- a/config/locales/devise.et.yml
+++ b/config/locales/devise.et.yml
@@ -46,7 +46,7 @@ et:
         unlock_instructions: 'Lahti lukustamise juhised'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Tere

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -43,7 +43,7 @@ fr:
         reset_password_instructions: "Instructions pour la réinitialisation du mot de passe"
         unlock_instructions: "Instructions pour le déverrouillage"
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Bienvenue

--- a/config/locales/devise.it.yml
+++ b/config/locales/devise.it.yml
@@ -45,7 +45,7 @@ it:
         unlock_instructions: "Istruzioni per lo sblocco dell'account"
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Ciao

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -44,7 +44,7 @@ ja:
         reset_password_instructions:  "パスワードのリセット方法"
         unlock_instructions:  "アカウントのロック解除方法"
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello:  "こんにちは"

--- a/config/locales/devise.nb.yml
+++ b/config/locales/devise.nb.yml
@@ -46,7 +46,7 @@ nb:
         unlock_instructions: 'Instrukser for åpning'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Hallo

--- a/config/locales/devise.nl.yml
+++ b/config/locales/devise.nl.yml
@@ -45,7 +45,7 @@ nl:
         unlock_instructions: 'Unlock Instructions'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Hello

--- a/config/locales/devise.pl.yml
+++ b/config/locales/devise.pl.yml
@@ -45,7 +45,7 @@ pl:
         unlock_instructions: 'Instrukcje odblokowywania'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Witaj

--- a/config/locales/devise.pt-BR.yml
+++ b/config/locales/devise.pt-BR.yml
@@ -44,7 +44,7 @@ pt-BR:
         unlock_instructions: 'Instruções de desbloqueio'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Olá

--- a/config/locales/devise.ru.yml
+++ b/config/locales/devise.ru.yml
@@ -45,7 +45,7 @@ ru:
         unlock_instructions: 'Инструкции по разблокированию'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: Здравствуйте

--- a/config/locales/devise.zh-CN.yml
+++ b/config/locales/devise.zh-CN.yml
@@ -45,7 +45,7 @@ zh-CN:
         unlock_instructions: '解锁说明'
 
 
-  locomotive_account:
+  locomotive:
     devise_mailer:
       common:
         hello: 你好


### PR DESCRIPTION
Devise i18n key for views are wrongs in local files.

cf: https://github.com/locomotivecms/engine/blob/master/app/views/locomotive/devise_mailer/reset_password_instructions.html.haml
