### PR TITLE
render nested templates correctly when refreshing

### DIFF
--- a/app/models/locomotive/snippet.rb
+++ b/app/models/locomotive/snippet.rb
@@ -54,7 +54,7 @@ module Locomotive
     def _change_snippet_inside_template(node)
       case node
       when Locomotive::Liquid::Tags::Snippet
-        node.refresh(self) if node.slug == self.slug
+        node.refresh(self, _default_context) if node.slug == self.slug
       when Locomotive::Liquid::Tags::InheritedBlock
         _change_snippet_inside_template(node.parent) if node.parent
       end
@@ -66,5 +66,8 @@ module Locomotive
       end
     end
 
+    def _default_context
+      {site: site}
+    end
   end
 end

--- a/lib/locomotive/liquid/tags/snippet.rb
+++ b/lib/locomotive/liquid/tags/snippet.rb
@@ -54,7 +54,7 @@ module Locomotive
             @partial = nil
           else
             @snippet_id = snippet.id
-            @partial = ::Liquid::Template.parse(snippet.template, @context.clone)
+            @partial = ::Liquid::Template.parse(snippet.template, context.merge(@context))
             @partial.root.context.clear
           end
         end

--- a/spec/models/locomotive/snippet_spec.rb
+++ b/spec/models/locomotive/snippet_spec.rb
@@ -49,6 +49,27 @@ describe Locomotive::Snippet do
 
     end
 
+    context 'for snippets inside a snippet' do
+      before :each do
+        @nested_snippet = FactoryGirl.create(:snippet, site: @site, slug: 'my_nested_test_snippet', template: "{% include 'my_test_snippet' %}")
+        @page = FactoryGirl.create(:page, site: @site, slug: 'my_page_here', raw_template: "{% include 'my_nested_test_snippet' %}")
+      end
+
+      it 'renders the nested snippet' do
+        Locomotive::Page.find(@page.id).render({}).should == 'a testing template'
+      end
+
+      it 'updates parent snippets with the new snippet template' do
+        @snippet.update_attributes(template: 'a new template')
+        Locomotive::Page.find(@page.id).render({}).should == 'a new template'
+      end
+
+      it 'when the parent snippet is updated child snippets are rendered correctly' do
+        @nested_snippet.update_attributes(template: "hello {% include 'my_test_snippet' %}")
+        Locomotive::Page.find(@page.id).render({}).should == 'hello a testing template'
+      end
+    end
+
     context '#i18n' do
 
       before :each do


### PR DESCRIPTION
When refreshing a node in an existing page, set the site in the context
so nested snippets can be resolved correctly.

This simple fix covers off most of the common cases for nested snippets.

One missing case that I know of is when you edit a nested snippet to add another nested snippet. It won't update the dependent snippets on the page. So if that snippet is edited it wont be updated in the page.

I have a branch that correctly addresses this case, by tracking snippet dependencies in a similar way to how pages currently operate. However if there are loops it can overflow the stack. I have a not so naïve way of implementing it that should resolve this case, but haven't found the time to do it yet. 
