### PR TITLE
config/locales: add missing translations for 'api_key' to German locale

### DIFF
--- a/config/locales/admin_ui.de.yml
+++ b/config/locales/admin_ui.de.yml
@@ -82,6 +82,10 @@ de:
     sites_picker:
       new: + Neue Webseite
 
+    api_key:
+      none: Bitte auf den Knopf klicken um den API Schlüssel zu generieren.
+      button: Neu generieren
+
     custom_fields:
       edit:
         title: Benutzerdefinierte Felder bearbeiten


### PR DESCRIPTION
Adding missing German translation for 'de.locomotive.api_key.*'.
