### PR TITLE
Fixing an issue that causes a JS error when fields are created or read with leading/trailing white space on ICanHandlebarz.js

### DIFF
--- a/vendor/assets/javascripts/locomotive/ICanHandlebarz.js
+++ b/vendor/assets/javascripts/locomotive/ICanHandlebarz.js
@@ -23,7 +23,7 @@ function ICanHandlebarz() {
         self[name] = function (data, title, raw) {
             data = data || {};
             var result = self.templates[name](data);
-            return raw? result: $(result);
+            return raw? result: $(result.trim();
         };
     };
 


### PR DESCRIPTION
I was unsure of where exactly this PR should point to, as it seems ICanHandlebarz hasn't been updated for a while.  The problem, essentially, is that when ICanHandlebarz.js:26 is called, if there is any whitespace (trailing or leading) on $(result), it will cause the method to throw an error, like so:

```
Uncaught Error: Syntax error, unrecognized expression: <input id="content_entry_image" name="content_entry[image]" type="file" /> 
```

This, in turn, results in the field that is supposed to be displayed not and getting removed from the DOM.  In order to resolve this, I just issued a trim on result before we try to load it and pass it back.
