### PR TITLE
Fixed empty fields in content_entry CSV export

### DIFF
--- a/app/models/locomotive/extensions/content_entry/csv.rb
+++ b/app/models/locomotive/extensions/content_entry/csv.rb
@@ -43,7 +43,7 @@ module Locomotive
           when :tags
             [*value].join(', ')
           else
-            value
+            value == nil ? '' : value
           end
         end
 

--- a/spec/models/locomotive/extensions/content_entry/csv_spec.rb
+++ b/spec/models/locomotive/extensions/content_entry/csv_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+module Locomotive
+  module Extensions
+    module ContentEntry
+      describe Csv do
+        before(:each) do
+          Locomotive::Site.any_instance.stubs(:create_default_pages!).returns(true)
+          @content_type = FactoryGirl.build(:content_type)
+          @content_type.entries_custom_fields.build label: 'Title', type: 'string'
+          @content_type.entries_custom_fields.build label: 'Description', type: 'text'
+          @content_type.entries_custom_fields.build label: 'Visible ?', type: 'boolean', name: 'visible'
+          @content_type.valid?
+          @content_type.send(:set_label_field)
+          @content_type.save!
+        end
+
+        it 'should export nil fields as empty strings' do
+          @entry = @content_type.entries.create!({
+            title: 'Locomotive',
+            visible: true
+          })
+
+          values = @entry.to_values
+          expect(values).to eq(['Locomotive', '', true, I18n.l(@entry.created_at, format: :long)])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Set up nil fields to appear as empty strings in the CSV, rather than being left out entirely
