### PR TITLE
Fix ETags to include cache_key and locale only.

### DIFF
--- a/lib/locomotive/render.rb
+++ b/lib/locomotive/render.rb
@@ -67,11 +67,8 @@ module Locomotive
 
       # Inputs which define the ETag for this response
       etag_inputs = {
-        'page'    => @page,
-        'params'  => {
-          'page_path'   => params[:page_path],
-          'locale'      => params[:locale]
-        }
+        'page'   => @page.cache_key,
+        'locale' => params[:locale]
       }
 
       if @page.with_cache?


### PR DESCRIPTION
The previous implementation of "better" ETags did not work as expected. This corrects the behaviour so that it uses Rails' built-in cache_key along with the locale only to build an ETag. The previous implementation failed to create the unique ETags as required and may even make things worse for people using simple or no caching on a page, with ETags never changing, possibly forcing users to hard-refresh browsers to see updated content.
