### PR TITLE
added environment variable default assign

### DIFF
--- a/lib/locomotive/render.rb
+++ b/lib/locomotive/render.rb
@@ -185,6 +185,7 @@ module Locomotive
     #
     def locomotive_default_assigns
       {
+        'env'               => Rails.env,
         'site'              => current_site.to_liquid,
         'page'              => @page,
         'models'            => Locomotive::Liquid::Drops::ContentTypes.new,


### PR DESCRIPTION
Pretty valuable assign, as it requires for multiple different things on the front-end, for example when using 3d party API rather than to mess the data, we can exclude blocks with 

`{{ env }} != 'production'`
