### PR TITLE
Added missing locale translations in Spanish locale

### DIFF
--- a/config/locales/admin_ui.es.yml
+++ b/config/locales/admin_ui.es.yml
@@ -10,6 +10,24 @@ es:
         notice: "La página requerida no existe."
         link: "&rarr; Volver"
 
+    locales:
+      es: Español
+      en: Inglés
+      fr: Francés
+      it: Italiano
+      ru: Ruso
+      de: Alemán
+      pl: Polaco
+      nl: Holandés
+      et: Estonio
+      pt-BR: "Portugués brasileño"
+      nb: Noruego
+      ja: Japonés
+      zh-CN: Chino
+      cs: Checo
+      bg: Búlgaro
+      sk: Eslovaco
+
     buttons:
       login: Iniciar sesión
       send_password: Enviar


### PR DESCRIPTION
Spanish locale is missing several key translations. I'll provide them as I find and add them.
