### PR TITLE
Update admin_ui.es.yml

### DIFF
--- a/config/locales/admin_ui.es.yml
+++ b/config/locales/admin_ui.es.yml
@@ -65,6 +65,7 @@ es:
         create: Crear
         update: Actualizar
         send: Enviar
+        disable_with: Pendiente...
 
     notifications:
       new_content_entry:


### PR DESCRIPTION
Missing locale causes error on the form for creating a content type instance. I'm adding the translation based in the current state of the admin_ui.en.yml
