### PR TITLE
Update `dragonfly` to the latest version and update corresponding template.

### DIFF
--- a/lib/generators/locomotive/install/templates/dragonfly.rb
+++ b/lib/generators/locomotive/install/templates/dragonfly.rb
@@ -1,12 +1,8 @@
-require 'dragonfly'
-
 # Configure
 Dragonfly.app.configure do
   plugin :imagemagick,
     convert_command:  `which convert`.strip.presence || '/usr/local/bin/convert',
     identify_command: `which identify`.strip.presence || '/usr/local/bin/identify'
-
-  protect_from_dos_attacks true
 
   secret '<%= generate_secret %>'
 

--- a/locomotive_cms.gemspec
+++ b/locomotive_cms.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'carrierwave-mongoid',             '~> 0.6.2'
   s.add_dependency 'fog',                             '~> 1.12.1'
-  s.add_dependency 'dragonfly',                       '~> 1.0.4'
+  s.add_dependency 'dragonfly',                       '~> 1.0.7'
   s.add_dependency 'rack-cache',                      '~> 1.1'
   s.add_dependency 'mimetype-fu',                     '~> 0.1.2'
 


### PR DESCRIPTION
Hey there,

just a small update for `dragonfly`. The `protect_from_dos_attacks` option was replaced by `verify_urls` which is enabled by default, see: https://github.com/markevans/dragonfly/commit/e88afeceb036fe4d44f7c7787c7e988e1350c2dc

I think the `require 'dragonfly'` is not needed.
