### PR TITLE
Update dragonfly to work with protocol-relative asset hosts

### DIFF
--- a/lib/locomotive/dragonfly.rb
+++ b/lib/locomotive/dragonfly.rb
@@ -27,6 +27,7 @@ module Locomotive
 
         clean_source!(source)
 
+        source.gsub!(/^\/\//, "https://")
         if source =~ /^http/
           file = self.app.fetch_url(source)
         else


### PR DESCRIPTION
A protocol-relative cloudfront URL breaks the Dragonfly resizing. (something like "//xxxxxxxxxxxx.cloudfront.net/xxxxxxxx") This fixes that.
