### PR TITLE
Update liquid tag for google analytics to use universal analytics

### DIFF
--- a/lib/locomotive/liquid/tags/google_analytics.rb
+++ b/lib/locomotive/liquid/tags/google_analytics.rb
@@ -17,17 +17,14 @@ module Liquid
 
         def render(context)
           %{
-          <script type="text/javascript">
+          <script>
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-            var _gaq = _gaq || [];
-            _gaq.push(['_setAccount', '#{@account_id}']);
-            _gaq.push(['_trackPageview']);
-
-            (function() \{
-              var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-              ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-              var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-            \})();
+            ga('create', '#{@account_id}', 'auto');
+            ga('send', 'pageview');
 
           </script>}
         end


### PR DESCRIPTION
Basic change to use new tracking code without the new cross device user id