### PR TITLE
Updated inline editor layout

### DIFF
--- a/app/assets/stylesheets/locomotive/inline_editor/layout.css.scss
+++ b/app/assets/stylesheets/locomotive/inline_editor/layout.css.scss
@@ -4,7 +4,11 @@ body {
 }
 
 #page {
-  position: relative;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   padding-top: 40px;
 
   iframe {


### PR DESCRIPTION
Changed the inline editor layout such that #page is guaranteed to take up the entire viewport. This solves a problem where a fixed-position HTML root tag in the iframe's document would cause the edit page to size incorrectly. Forcing the #page element and therefore the iframe inside it to take up the full viewport seems a sensible way to avoid this, and should not have any adverse effects.
