### PR TITLE
add woff2 to acceptable mime types

### DIFF
--- a/app/uploaders/locomotive/theme_asset_uploader.rb
+++ b/app/uploaders/locomotive/theme_asset_uploader.rb
@@ -10,7 +10,7 @@ module Locomotive
     end
 
     def extension_white_list
-      %w(jpg jpeg gif png css js swf flv eot svg ttf woff otf ico htc)
+      %w(jpg jpeg gif png css js swf flv eot svg ttf woff woff2 otf ico htc)
     end
 
     def self.url_for(site, path)

--- a/lib/locomotive/carrierwave.rb
+++ b/lib/locomotive/carrierwave.rb
@@ -7,6 +7,7 @@ require 'locomotive/carrierwave/patches'
 # register missing mime types
 EXTENSIONS[:eot] = 'application/vnd.ms-fontobject'
 EXTENSIONS[:woff] = 'application/x-woff'
+EXTENSIONS[:woff2] = 'application/x-woff2'
 EXTENSIONS[:otf] = 'application/octet-stream'
 
 # Allow retina images

--- a/lib/locomotive/carrierwave/asset.rb
+++ b/lib/locomotive/carrierwave/asset.rb
@@ -25,7 +25,7 @@ module Locomotive
               pdf:        ['application/pdf', 'application/x-pdf'],
               stylesheet: ['text/css'],
               javascript: ['text/javascript', 'text/js', 'application/x-javascript', 'application/javascript', 'text/x-component'],
-              font:       [/^application\/.*font/, 'application/x-font-ttf', 'application/vnd.ms-fontobject', 'image/svg+xml', 'application/x-woff', 'application/x-font-truetype', 'application/x-font-woff']
+              font:       [/^application\/.*font/, 'application/x-font-ttf', 'application/vnd.ms-fontobject', 'image/svg+xml', 'application/x-woff', 'application/x-woff2', 'application/x-font-truetype', 'application/x-font-woff', 'application/x-font-woff2']
             }
           end
 


### PR DESCRIPTION
Seems latest fontawesome is now supporting woff2. Just added woff2 support to engine so I could wagon push.