### PR TITLE
fixed unsafe_token_authentication_params: made it select email from db

### DIFF
--- a/app/controllers/locomotive/concerns/token_authentication_controller.rb
+++ b/app/controllers/locomotive/concerns/token_authentication_controller.rb
@@ -23,6 +23,7 @@ module Locomotive
       def unsafe_token_authentication_params
         if Locomotive.config.unsafe_token_authentication
           params[:locomotive_account_token] = params[:auth_token]
+          params[:locomotive_account_email] = Locomotive::Account.where(authentication_token: params[:auth_token]).first.try(:email)
         end
       end
 


### PR DESCRIPTION
please, merge it asap
without this small fix engine just did not work for me with the latest version of SimpleTokenAuthentication
see Gemfile.lock  below:

GIT
  remote: git://github.com/locomotivecms/custom_fields.git
  revision: 15cceb66ed22e96af57b5cacc1f131665997ab50
  branch: mongoid_4
  specs:
    custom_fields (2.4.0.rc1)
      activesupport (~> 4.2.0)
      carrierwave-mongoid (~> 0.7.1)
      monetize (~> 1.1.0)
      mongoid (~> 4.0.0)

PATH
  remote: /Users/dmitry/Projects/locomotivecms/engine
  specs:
    locomotive_cms (3.0.0)
      RedCloth (~> 4.2.8)
      actionmailer-with-request (~> 0.4.0)
      autoprefixer-rails (~> 5.0.0.2)
      backbone-on-rails (~> 1.1.2.0)
      bootstrap-kaminari-views (~> 0.0.5)
      bootstrap-sass (~> 3.3.3)
      carrierwave-mongoid (~> 0.7)
      cells (~> 3.11.3)
      codemirror-rails (~> 4.8)
      compass-rails (= 2.0.4)
      devise (~> 3.4.1)
      devise-encryptable (~> 0.2.0)
      dragonfly (~> 1.0.7)
      flash_cookie_session (~> 1.1.1)
      fog (~> 1.27.0)
      font-awesome-sass (~> 4.2.2)
      haml (~> 4.0.2)
      highline (~> 1.6.2)
      httparty (~> 0.13.3)
      jquery-rails (~> 4.0.3)
      jquery-ui-rails (~> 5.0.3)
      kaminari (= 0.16.1)
      locomotivecms_solid (~> 0.2.2)
      mime-types (~> 2.4.3)
      mimetype-fu (~> 0.1.2)
      mongo_session_store-rails4 (~> 5.1.0)
      mongoid (~> 4.0.0)
      mongoid-tree (~> 2.0.0)
      multi_json (~> 1.10.1)
      pundit (~> 0.3.0)
      rack-cache (~> 1.1)
      rails (~> 4.2.0)
      rake (~> 10.4.2)
      redcarpet (~> 3.2.2)
      responders (~> 2.0.2)
      sanitize (~> 3.1.0)
      select2-rails (~> 3.5.9)
      simple_form (~> 3.1.0)
      simple_token_authentication (~> 1.7.0)
      stringex (~> 2.5.2)

GEM
  remote: https://rubygems.org/
  specs:
    CFPropertyList (2.3.0)
    RedCloth (4.2.9)
    actionmailer (4.2.0)
      actionpack (= 4.2.0)
      actionview (= 4.2.0)
      activejob (= 4.2.0)
      mail (~> 2.5, >= 2.5.4)
      rails-dom-testing (~> 1.0, >= 1.0.5)
    actionmailer-with-request (0.4.0)
      rails (>= 3)
    actionpack (4.2.0)
      actionview (= 4.2.0)
      activesupport (= 4.2.0)
      rack (~> 1.6.0)
      rack-test (~> 0.6.2)
      rails-dom-testing (~> 1.0, >= 1.0.5)
      rails-html-sanitizer (~> 1.0, >= 1.0.1)
    actionview (4.2.0)
      activesupport (= 4.2.0)
      builder (~> 3.1)
      erubis (~> 2.7.0)
      rails-dom-testing (~> 1.0, >= 1.0.5)
      rails-html-sanitizer (~> 1.0, >= 1.0.1)
    activejob (4.2.0)
      activesupport (= 4.2.0)
      globalid (>= 0.3.0)
    activemodel (4.2.0)
      activesupport (= 4.2.0)
      builder (~> 3.1)
    activerecord (4.2.0)
      activemodel (= 4.2.0)
      activesupport (= 4.2.0)
      arel (~> 6.0)
    activeresource (4.0.0)
      activemodel (~> 4.0)
      activesupport (~> 4.0)
      rails-observers (~> 0.1.1)
    activesupport (4.2.0)
      i18n (~> 0.7)
      json (~> 1.7, >= 1.7.7)
      minitest (~> 5.1)
      thread_safe (~> 0.3, >= 0.3.4)
      tzinfo (~> 1.1)
    addressable (2.3.6)
    arel (6.0.0)
    autoprefixer-rails (5.0.0.3)
      execjs
      json
    backbone-on-rails (1.1.2.0)
      actionmailer
      actionpack
      activemodel
      activeresource
      eco
      ejs
      jquery-rails
      railties
    bcrypt (3.1.10)
    binding_of_caller (0.7.2)
      debug_inspector (>= 0.0.1)
    bootstrap-kaminari-views (0.0.5)
      kaminari (>= 0.13)
      rails (>= 3.1)
    bootstrap-sass (3.3.3)
      autoprefixer-rails (>= 5.0.0.1)
      sass (>= 3.2.19)
    bson (2.3.0)
    builder (3.2.2)
    byebug (3.5.1)
      columnize (~> 0.8)
      debugger-linecache (~> 1.2)
      slop (~> 3.6)
    carrierwave (0.10.0)
      activemodel (>= 3.2.0)
      activesupport (>= 3.2.0)
      json (>= 1.7)
      mime-types (>= 1.16)
    carrierwave-mongoid (0.7.1)
      carrierwave (>= 0.8.0, < 0.11.0)
      mongoid (>= 3.0, < 5.0)
      mongoid-grid_fs (>= 1.3, < 3.0)
    cells (3.11.3)
      actionpack (>= 3.0)
      railties (>= 3.0)
      uber (~> 0.0.8)
    chunky_png (1.3.3)
    codemirror-rails (4.8)
      railties (>= 3.0, < 5)
    coderay (1.1.0)
    coffee-rails (4.1.0)
      coffee-script (>= 2.2.0)
      railties (>= 4.0.0, < 5.0)
    coffee-script (2.3.0)
      coffee-script-source
      execjs
    coffee-script-source (1.9.0)
    columnize (0.9.0)
    compass (1.0.3)
      chunky_png (~> 1.2)
      compass-core (~> 1.0.2)
      compass-import-once (~> 1.0.5)
      rb-fsevent (>= 0.9.3)
      rb-inotify (>= 0.9)
      sass (>= 3.3.13, < 3.5)
    compass-core (1.0.3)
      multi_json (~> 1.0)
      sass (>= 3.3.0, < 3.5)
    compass-import-once (1.0.5)
      sass (>= 3.2, < 3.5)
    compass-rails (2.0.4)
      compass (~> 1.0.0)
      sass-rails (<= 5.0.1)
      sprockets (< 2.13)
    connection_pool (2.1.1)
    crass (1.0.1)
    debug_inspector (0.0.2)
    debugger-linecache (1.2.0)
    devise (3.4.1)
      bcrypt (~> 3.0)
      orm_adapter (~> 0.1)
      railties (>= 3.2.6, < 5)
      responders
      thread_safe (~> 0.1)
      warden (~> 1.2.3)
    devise-encryptable (0.2.0)
      devise (>= 2.1.0)
    dragonfly (1.0.7)
      addressable (~> 2.3)
      multi_json (~> 1.0)
      rack
    eco (1.0.0)
      coffee-script
      eco-source
      execjs
    eco-source (1.1.0.rc.1)
    ejs (1.1.1)
    erubis (2.7.0)
    excon (0.44.0)
    execjs (2.2.2)
    ffi (1.9.6)
    fission (0.5.0)
      CFPropertyList (~> 2.2)
    flash_cookie_session (1.1.6)
      rails (>= 3.0)
    fog (1.27.0)
      fog-atmos
      fog-aws (~> 0.0)
      fog-brightbox (~> 0.4)
      fog-core (~> 1.27, >= 1.27.3)
      fog-ecloud
      fog-json
      fog-profitbricks
      fog-radosgw (>= 0.0.2)
      fog-sakuracloud (>= 0.0.4)
      fog-serverlove
      fog-softlayer
      fog-storm_on_demand
      fog-terremark
      fog-vmfusion
      fog-voxel
      fog-xml (~> 0.1.1)
      ipaddress (~> 0.5)
      nokogiri (~> 1.5, >= 1.5.11)
    fog-atmos (0.1.0)
      fog-core
      fog-xml
    fog-aws (0.0.8)
      fog-core (~> 1.27)
      fog-json (~> 1.0)
      fog-xml (~> 0.1)
      ipaddress (~> 0.8)
    fog-brightbox (0.7.1)
      fog-core (~> 1.22)
      fog-json
      inflecto (~> 0.0.2)
    fog-core (1.28.0)
      builder
      excon (~> 0.38)
      formatador (~> 0.2)
      mime-types
      net-scp (~> 1.1)
      net-ssh (>= 2.1.3)
    fog-ecloud (0.0.2)
      fog-core
      fog-xml
    fog-json (1.0.0)
      multi_json (~> 1.0)
    fog-profitbricks (0.0.1)
      fog-core
      fog-xml
      nokogiri
    fog-radosgw (0.0.3)
      fog-core (>= 1.21.0)
      fog-json
      fog-xml (>= 0.0.1)
    fog-sakuracloud (1.0.0)
      fog-core
      fog-json
    fog-serverlove (0.1.1)
      fog-core
      fog-json
    fog-softlayer (0.4.0)
      fog-core
      fog-json
    fog-storm_on_demand (0.1.0)
      fog-core
      fog-json
    fog-terremark (0.0.3)
      fog-core
      fog-xml
    fog-vmfusion (0.0.1)
      fission
      fog-core
    fog-voxel (0.0.2)
      fog-core
      fog-xml
    fog-xml (0.1.1)
      fog-core
      nokogiri (~> 1.5, >= 1.5.11)
    font-awesome-sass (4.2.2)
      sass (~> 3.2)
    formatador (0.2.5)
    globalid (0.3.0)
      activesupport (>= 4.1.0)
    haml (4.0.6)
      tilt
    highline (1.6.21)
    hike (1.2.3)
    httparty (0.13.3)
      json (~> 1.8)
      multi_xml (>= 0.5.2)
    i18n (0.7.0)
    inflecto (0.0.2)
    ipaddress (0.8.0)
    jbuilder (2.2.6)
      activesupport (>= 3.0.0, < 5)
      multi_json (~> 1.2)
    jquery-rails (4.0.3)
      rails-dom-testing (~> 1.0)
      railties (>= 4.2.0)
      thor (>= 0.14, < 2.0)
    jquery-ui-rails (5.0.3)
      railties (>= 3.2.16)
    json (1.8.2)
    kaminari (0.16.1)
      actionpack (>= 3.0.0)
      activesupport (>= 3.0.0)
    locomotive_liquid (2.4.2)
    locomotivecms_solid (0.2.2)
      locomotive_liquid (~> 2.4.2)
    loofah (2.0.1)
      nokogiri (>= 1.5.9)
    mail (2.6.3)
      mime-types (>= 1.16, < 3)
    method_source (0.8.2)
    mime-types (2.4.3)
    mimetype-fu (0.1.2)
    mini_portile (0.6.2)
    minitest (5.5.1)
    monetize (1.1.0)
      money (~> 6.5.0)
    money (6.5.0)
      i18n (>= 0.6.4, <= 0.7.0)
    mongo_session_store-rails4 (5.1.0)
      actionpack (>= 3.1)
    mongoid (4.0.1)
      activemodel (~> 4.0)
      moped (~> 2.0.0)
      origin (~> 2.1)
      tzinfo (>= 0.3.37)
    mongoid-grid_fs (2.1.0)
      mime-types (>= 1.0, < 3.0)
      mongoid (>= 3.0, < 5.0)
    mongoid-tree (2.0.0)
      mongoid (>= 4.0, <= 5.0)
    moped (2.0.3)
      bson (~> 2.2)
      connection_pool (~> 2.0)
      optionable (~> 0.2.0)
    multi_json (1.10.1)
    multi_xml (0.5.5)
    net-scp (1.2.1)
      net-ssh (>= 2.6.5)
    net-ssh (2.9.2)
    nokogiri (1.6.6.2)
      mini_portile (~> 0.6.0)
    nokogumbo (1.2.0)
      nokogiri
    optionable (0.2.0)
    origin (2.1.1)
    orm_adapter (0.5.0)
    pry (0.10.1)
      coderay (~> 1.1.0)
      method_source (~> 0.8.1)
      slop (~> 3.4)
    pry-byebug (2.0.0)
      byebug (~> 3.4)
      pry (~> 0.10)
    pry-rails (0.3.2)
      pry (>= 0.9.10)
    pundit (0.3.0)
      activesupport (>= 3.0.0)
    rack (1.6.0)
    rack-cache (1.2)
      rack (>= 0.4)
    rack-test (0.6.3)
      rack (>= 1.0)
    rails (4.2.0)
      actionmailer (= 4.2.0)
      actionpack (= 4.2.0)
      actionview (= 4.2.0)
      activejob (= 4.2.0)
      activemodel (= 4.2.0)
      activerecord (= 4.2.0)
      activesupport (= 4.2.0)
      bundler (>= 1.3.0, < 2.0)
      railties (= 4.2.0)
      sprockets-rails
    rails-deprecated_sanitizer (1.0.3)
      activesupport (>= 4.2.0.alpha)
    rails-dom-testing (1.0.5)
      activesupport (>= 4.2.0.beta, < 5.0)
      nokogiri (~> 1.6.0)
      rails-deprecated_sanitizer (>= 1.0.1)
    rails-html-sanitizer (1.0.1)
      loofah (~> 2.0)
    rails-observers (0.1.2)
      activemodel (~> 4.0)
    railties (4.2.0)
      actionpack (= 4.2.0)
      activesupport (= 4.2.0)
      rake (>= 0.8.7)
      thor (>= 0.18.1, < 2.0)
    rake (10.4.2)
    rb-fsevent (0.9.4)
    rb-inotify (0.9.5)
      ffi (>= 0.5.0)
    rdoc (4.2.0)
      json (~> 1.4)
    redcarpet (3.2.2)
    responders (2.0.2)
      railties (>= 4.2.0.alpha, < 5)
    sanitize (3.1.0)
      crass (~> 1.0.1)
      nokogiri (>= 1.4.4)
      nokogumbo (= 1.2.0)
    sass (3.4.11)
    sass-rails (5.0.1)
      railties (>= 4.0.0, < 5.0)
      sass (~> 3.1)
      sprockets (>= 2.8, < 4.0)
      sprockets-rails (>= 2.0, < 4.0)
      tilt (~> 1.1)
    sdoc (0.4.1)
      json (~> 1.7, >= 1.7.7)
      rdoc (~> 4.0)
    select2-rails (3.5.9.2)
      thor (~> 0.14)
    simple_form (3.1.0)
      actionpack (~> 4.0)
      activemodel (~> 4.0)
    simple_token_authentication (1.7.0)
      actionmailer (>= 3.2.6, < 5)
      actionpack (>= 3.2.6, < 5)
      devise (~> 3.2)
    slop (3.6.0)
    spring (1.2.0)
    sprockets (2.12.3)
      hike (~> 1.2)
      multi_json (~> 1.0)
      rack (~> 1.0)
      tilt (~> 1.1, != 1.3.0)
    sprockets-rails (2.2.4)
      actionpack (>= 3.0)
      activesupport (>= 3.0)
      sprockets (>= 2.8, < 4.0)
    sqlite3 (1.3.10)
    stringex (2.5.2)
    thor (0.19.1)
    thread_safe (0.3.4)
    tilt (1.4.1)
    turbolinks (2.5.3)
      coffee-rails
    tzinfo (1.2.2)
      thread_safe (~> 0.1)
    uber (0.0.13)
    uglifier (2.7.0)
      execjs (>= 0.3.0)
      json (>= 1.8.0)
    warden (1.2.3)
      rack (>= 1.0)
    web-console (2.0.0)
      activemodel (~> 4.0)
      binding_of_caller (>= 0.7.2)
      railties (~> 4.0)
      sprockets-rails (>= 2.0, < 4.0)

PLATFORMS
  ruby

DEPENDENCIES
  byebug
  coffee-rails (~> 4.1.0)
  custom_fields!
  jbuilder (~> 2.0)
  jquery-rails
  locomotive_cms!
  pry
  pry-byebug
  pry-rails
  rails (= 4.2.0)
  sass-rails (~> 5.0)
  sdoc (~> 0.4.0)
  spring
  sqlite3
  turbolinks
  uglifier (>= 1.3.0)
  web-console (~> 2.0)