### PR TITLE
Prepare for Teatro

### DIFF
--- a/.sandbox.sh
+++ b/.sandbox.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Used in the sandbox rake task in Rakefile
+
+# Prepare outside engine directory
+CURRENT_DIR=`pwd`
+rm -rf /tmp/sandbox
+mkdir /tmp/sandbox
+cd /tmp/sandbox
+
+# Initialize sandbox application
+if [ ! -d "/tmp/sandbox" ]; then
+  echo 'sandbox rails application failed'
+  exit 1
+fi
+
+cat <<RUBY >> Gemfile
+source 'https://rubygems.org'
+
+gem 'rails', '~> 4.2.0'
+RUBY
+
+bundle install --gemfile Gemfile
+bundle exec rails new . --skip-active-record --skip-test-unit --skip-javascript --skip-bundle --force
+
+cat <<RUBY >> Gemfile
+gem 'custom_fields', github: 'locomotivecms/custom_fields', ref: '15cceb66ed'
+gem "locomotive_cms", path: "$CURRENT_DIR", :require => "locomotive/engine"
+gem 'formtastic'
+gem 'compass'
+gem 'compass-rails'
+gem 'coffee-rails'
+gem 'therubyracer'
+gem 'unicorn'
+RUBY
+
+bundle install --gemfile Gemfile
+RAILS_ENV=development bundle exec rails g locomotive:install
+
+cat <<RUBY > config/initializers/carrierwave.rb
+CarrierWave.configure do |config|
+  config.cache_dir = File.join(Rails.root, 'tmp', 'uploads')
+  config.storage = :file
+  config.root = File.join(Rails.root, 'public')
+end
+RUBY
+
+# Replace generated mongo config
+if [ -f "$CURRENT_DIR/config/mongoid.yml" ]; then
+  echo 'Copy prepared mongoid config to target directory'
+  cp $CURRENT_DIR/config/mongoid.yml /tmp/sandbox/mongoid.yml
+fi
+sed -i '/identity_map_enabled/d' ./config/mongoid.yml
+
+bundle exec rake assets:precompile

--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,0 +1,14 @@
+stage:
+  before:
+    - ./.sandbox.sh
+
+  run:
+    - cd /tmp/sandbox && bundle exec rails server
+
+  database:
+    - cd /tmp/sandbox && bundle exec rake db:create db:migrate development:bootstrap
+
+config:
+  database: mongodb
+  services:
+    - mongodb


### PR DESCRIPTION
Hey!

I am developer at [Teatro.io](https://teatro.io) and I want to offer you our service — it automatically creates a staging server for each opened pull request.

Teatro.io is free for open source projects and some large projects like GitLab, ErrBit, OpenProject, Spree, Fat Free CRM and others are already using Teatro for free stage servers.

Here's URL of Teatro stage server for my fork of Locomotive:  http://teatro.saratovsource-engine-e6ef31cbd7e03b1381d5.ttrcloud.com/locomotive

When you connect project to Teatro, we'll automatically post a comment (via @TeatroIO) with link to unique stage server that was made for this specific branch (see https://github.com/saratovsource/engine/pull/1#issuecomment-73774925 for example).

To use Teatro you need:
- sign in using Github account on https://teatro.io
- add your project

Benefits:
- demo for new users (always up to date!)
- the way to test changes: each Pull Request gets separate stage server
- **FREE** for open source!
