### PR TITLE
added carrierwave-aws dependency

### DIFF
--- a/locomotive_cms.gemspec
+++ b/locomotive_cms.gemspec
@@ -62,6 +62,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bazaar',                          '~> 0.0.2'
 
   s.add_dependency 'carrierwave-mongoid',             '~> 0.7.1'
+  s.add_dependency 'carrierwave-aws',                 '~> 1.0.0'
   s.add_dependency 'dragonfly',                       '~> 1.0.7'
   s.add_dependency 'rack-cache',                      '~> 1.1'
   s.add_dependency 'mimetype-fu',                     '~> 0.1.2'


### PR DESCRIPTION
related to issue #1064 . after fix was commited, a new project cannot be started in production mode if carrierwave-aws gem is not installed