### PR TITLE
Added to_liquid method for ActionDispatch::Http::UploadedFile class

### DIFF
--- a/config/initializers/uploaded_file.rb
+++ b/config/initializers/uploaded_file.rb
@@ -1,0 +1,9 @@
+module ActionDispatch
+	module Http
+		class UploadedFile
+			def to_liquid
+				self.instance_values.merge('tempfile' => self.tempfile.path)
+			end
+		end
+	end
+end

--- a/spec/lib/uploaded_file_spec.rb
+++ b/spec/lib/uploaded_file_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe ActionDispatch::Http::UploadedFile do
+
+  it 'correctly converts the uploaded file into a liquid object' do
+    file = File.open(Rails.root + 'spec/tmp/test_pdf.pdf', 'w')
+    uploaded_file = ActionDispatch::Http::UploadedFile.new(tempfile: file, filename: File.basename(file), type: "application/pdf")
+    liquid_object = uploaded_file.to_liquid
+    liquid_object['original_filename'].should == File.basename(file)
+    liquid_object['content_type'].should == 'application/pdf'
+    liquid_object['tempfile'].should == file.path
+  end
+
+end


### PR DESCRIPTION
Added to_liquid method for ActionDispatch::Http::UploadedFile to allow for additional handling of uploaded files beyond using the public submission URL.