### PR TITLE
Updated ActionDispatch::Http::UploadedFile to_liquid method to not ov…

### DIFF
--- a/config/initializers/uploaded_file.rb
+++ b/config/initializers/uploaded_file.rb
@@ -2,7 +2,7 @@ module ActionDispatch
 	module Http
 		class UploadedFile
 			def to_liquid
-				self.instance_values.merge('tempfile' => self.tempfile.path)
+				self.instance_values
 			end
 		end
 	end

--- a/spec/lib/uploaded_file_spec.rb
+++ b/spec/lib/uploaded_file_spec.rb
@@ -8,7 +8,7 @@ describe ActionDispatch::Http::UploadedFile do
     liquid_object = uploaded_file.to_liquid
     liquid_object['original_filename'].should == File.basename(file)
     liquid_object['content_type'].should == 'application/pdf'
-    liquid_object['tempfile'].should == file.path
+    liquid_object['tempfile'].should == file
   end
 
 end


### PR DESCRIPTION
Updated ActionDispatch::Http::UploadedFile to_liquid method to not override tempfile attribute. We originally replaced the tempfile object with the filepath to the tempfile, which ended up not producing intended behavior.