### PR TITLE
Pass all configuration options to steam adapter

### DIFF
--- a/lib/locomotive/steam_adaptor.rb
+++ b/lib/locomotive/steam_adaptor.rb
@@ -19,7 +19,8 @@ Locomotive::Steam.configure do |config|
 
   # rely on Mongoid for the connection information
   if mongoid = Mongoid.configure.clients[:default]
-    options = mongoid[:uri] ? mongoid.slice(:uri) : mongoid.slice(:database, :hosts, :username, :password)
+    options = mongoid[:uri] ? mongoid.slice(:uri) : mongoid.slice(:hosts, :database)
+    options.merge!(mongoid[:options].symbolize_keys) if mongoid[:options]
     config.adapter = { name: :'mongoDB' }.merge(options.symbolize_keys)
   end
 


### PR DESCRIPTION
Correctly merge the credentials as part of all client options into the steam
configuration hash. This allows adaption of relevant Mongoid options by
the steam client.

`:username` and `:password` were not extracted from the `:options` hash correctly which entirely broke authentication with MongoDB. Now additional keys like `:auth_source` and `:max_pool_size` are also passed to steam. I am currently preparing another PR on steam that will use these additional options for configuring the `Mongo::Client` accordingly.