### PR TITLE
add LOCOMOTIVE_STEAM_LOG env var

### DIFF
--- a/lib/locomotive/steam_adaptor.rb
+++ b/lib/locomotive/steam_adaptor.rb
@@ -52,6 +52,6 @@ end
 
 Locomotive::Common.reset
 Locomotive::Common.configure do |config|
-  config_file = Rails.root.join('log', 'steam.log')
+  config_file = ENV['LOCOMOTIVE_STEAM_LOG'] || Rails.root.join('log', 'steam.log')
   config.notifier = Locomotive::Common::Logger.setup(config_file.to_s)
 end


### PR DESCRIPTION
To avoid logging into the root directory of the application and allow integration into other logging schemes. (in my case to allow deployment via NixOps)