### PR TITLE
Don't include wysihtml5_editor css unless live editing

### DIFF
--- a/lib/locomotive/steam/middlewares/wysihtml_css.rb
+++ b/lib/locomotive/steam/middlewares/wysihtml_css.rb
@@ -11,7 +11,7 @@ module Locomotive
         def call(env)
           status, headers, response = @app.call(env)
 
-          if content?(env['steam.page'], response)
+          if env['steam.live_editing'] && content?(env['steam.page'], response)
             url   = ::ActionController::Base.helpers.stylesheet_url('locomotive/wysihtml5_editor')
             html  = %(<link rel="stylesheet" type="text/css" href="#{url}">)
             response.first.gsub!('</head>', %(#{html}</head>))

--- a/spec/requests/locomotive/steam/wysihtml_css_spec.rb
+++ b/spec/requests/locomotive/steam/wysihtml_css_spec.rb
@@ -33,7 +33,15 @@ describe Locomotive::Steam::Middlewares::WysihtmlCss do
 
       let(:html) { '<html><head></head><body></body></html>' }
 
-      it { is_expected.to match(%r(<html><head><link rel="stylesheet" type="text/css" href="/assets/locomotive/wysihtml5_editor-[^.]+.css"></head><body></body></html>)) }
+      it { is_expected.to match(%r(<html><head></head><body></body></html>)) }
+
+      describe 'live editing' do
+
+        before { env['steam.live_editing'] = true }
+
+        it { is_expected.to match(%r(<html><head><link rel="stylesheet" type="text/css" href="/assets/locomotive/wysihtml5_editor-[^.]+.css"></head><body></body></html>)) }
+
+      end
 
     end
 


### PR DESCRIPTION
Before this fix, wysihtml5_editor css was always included, and it cause
all clients to download it.

This stylesheet should only be included when the page is being edited
by an editor. It should not be served for all visitors of a website.

I discovered this bug because google page speed insights complained
"Eliminate render-blocking JavaScript and CSS in above-the-fold content"

I'm not entirely sure when the wysiwyg editor is included, so this is
my best guess on a fix.
