### PR TITLE
Change positioning of wysiwyg popover options

### DIFF
--- a/app/assets/javascripts/locomotive/views/inputs/rte/link_view.js.coffee
+++ b/app/assets/javascripts/locomotive/views/inputs/rte/link_view.js.coffee
@@ -26,7 +26,7 @@ class Locomotive.Views.Inputs.Rte.LinkView extends Backbone.View
     @$content.show()
     @$link.popover
       container:  @$link.parents('fieldset')
-      placement:  'right'
+      placement:  'bottom'
       content:    @$content
       html:       true
       trigger:    'manual'

--- a/app/assets/javascripts/locomotive/views/inputs/rte/table_view.js.coffee
+++ b/app/assets/javascripts/locomotive/views/inputs/rte/table_view.js.coffee
@@ -24,7 +24,7 @@ class Locomotive.Views.Inputs.Rte.TableView extends Backbone.View
     @$content.show()
     @$link.popover
       container:  @$link.parents('fieldset')
-      placement:  'right'
+      placement:  'bottom'
       content:    @$content
       html:       true
       trigger:    'manual'

--- a/app/assets/javascripts/locomotive/views/inputs/rte_view.js.coffee.erb
+++ b/app/assets/javascripts/locomotive/views/inputs/rte_view.js.coffee.erb
@@ -59,7 +59,7 @@ class Locomotive.Views.Inputs.RteView extends Backbone.View
     html    = $button.next('.style-dialog-content').html()
 
     @$style_popover = @$style_popover || ($button.popover
-      placement:  'top'
+      placement:  'bottom'
       content:    html
       html:       true
       title:      undefined)

--- a/app/assets/stylesheets/locomotive/old/form/_popover.scss
+++ b/app/assets/stylesheets/locomotive/old/form/_popover.scss
@@ -1,8 +1,4 @@
 .popover {
-  margin-top: 60px !important;
-  .arrow {
-    margin-top: -71px !important;
-  }
   .simple_form {
     padding-bottom: 0;
 


### PR DESCRIPTION
The popovers were being positioned like this:
![bad-position1](https://cloud.githubusercontent.com/assets/8692590/20349084/0f19e9fa-ac09-11e6-9f4b-94351e7ef0ef.png)
![bad-position2](https://cloud.githubusercontent.com/assets/8692590/20349089/1310d104-ac09-11e6-84a0-7ba07e239e22.png)

This changes make them position at the bottom of the button, so they can be closed.
![good-position1](https://cloud.githubusercontent.com/assets/8692590/20349111/2e5e8a78-ac09-11e6-9d05-02b14d3d6fad.png)
![good-position2](https://cloud.githubusercontent.com/assets/8692590/20349114/30ee8b44-ac09-11e6-89ae-66c822a94877.png)


