### PR TITLE
Fix ability to use content entry fields in "public_submission_title_template"

### DIFF
--- a/app/models/locomotive/concerns/content_type/public_submission_title_template.rb
+++ b/app/models/locomotive/concerns/content_type/public_submission_title_template.rb
@@ -13,7 +13,7 @@ module Locomotive
           template = ::Liquid::Template.parse(self.public_submission_title_template, {})
 
           assigns   = { 'site' => self.site, 'entry' => entry }.merge(options)
-          registers = { site: self.site }
+          registers = { site: self.site, services: Locomotive::Steam::Services.build_instance }
 
           template.render(::Liquid::Context.new({}, assigns, registers))
         end


### PR DESCRIPTION
This allows you to use entry variables in the notification email subject as intended. It was previously broken because 'services' was undefined.

Example content type configuration:

`public_submission_title_template: New message from {{entry.name}}`

Just a note, this is not currently in the v3 docs