### PR TITLE
Fix datetime-fields not showing time in German locale

### DIFF
--- a/config/locales/default.de.yml
+++ b/config/locales/default.de.yml
@@ -6,7 +6,7 @@ de:
     yesterday_at: "gestern um"
   time:
     formats:
-      default: "%d.%m.%Y"
+      default: "%d.%m.%Y %H:%M"
       time: "%H:%M"
   pagination:
     previous: "&laquo; Zurück"


### PR DESCRIPTION
When the backend locale is 🇩🇪, the datetime field in model edit form does not allow to edit the time anymore.
<img width="498" alt="screen shot 2017-01-22 at 17 23 35" src="https://cloud.githubusercontent.com/assets/2587503/22183850/aba643f2-e0c7-11e6-9ddf-591d09d8e9d8.png">

As compared with 🇬🇧 , where it is shown correctly:
<img width="437" alt="screen shot 2017-01-22 at 17 23 55" src="https://cloud.githubusercontent.com/assets/2587503/22183853/bebe3508-e0c7-11e6-9b79-d4bb3608abe6.png">

Strangely, :de was the only language concerned. All the other locales contain some form of `%H:%M`.