### PR TITLE
fix issue #1197 (account.avatar.url is a frozen string)

### DIFF
--- a/lib/locomotive/dragonfly.rb
+++ b/lib/locomotive/dragonfly.rb
@@ -25,7 +25,7 @@ module Locomotive
       if source.is_a?(String) || source.is_a?(Hash) # simple string or drop
         source = source['url'] if source.is_a?(Hash)
 
-        clean_source!(source)
+        source = clean_source(source)
 
         if source =~ /^http/
           file = self.app.fetch_url(source)
@@ -50,12 +50,14 @@ module Locomotive
 
     protected
 
-    def self.clean_source!(source)
+    def self.clean_source(source)
       # remove the leading / trailing whitespaces
-      source.strip!
+      _source = source.strip
 
       # remove the query part (usually, timestamp) if local file
-      source.sub!(/(\?.*)$/, '') unless source =~ /^http/
+      _source = _source.sub(/(\?.*)$/, '') unless _source =~ /^http/
+
+      _source
     end
 
   end

--- a/spec/helpers/locomotive/shared/accounts_helper_spec.rb
+++ b/spec/helpers/locomotive/shared/accounts_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Locomotive::Shared::AccountsHelper do
+
+  describe 'account_avatar_url' do
+
+    let(:account) { create(:account, avatar: FixturedAsset.open('5k.png')).reload }
+
+    subject { account_avatar_url(account) }
+
+    it { expect(subject).to match(/^\/images\/dynamic\/[^\/]+\/5k.png\?sha=.*$/) }
+
+  end
+
+end
+
+


### PR DESCRIPTION
Hey @did. First off, thank you for all of your hard work on Locomotive. I've been using it for many years now and I hope you know how much I appreciate all that you have done.

I'm creating this PR in case you want to release another `3.2.x` that fixes #1197. This patch was necessary for me to be able to use the admin interface on Heroku on `ruby 2.3`. It just cherry-picks your earlier commit into the `3.2.x` branch.

I would update to the `3.3.x` branch, but unfortunately it's not compatible with the `platform-api` gem, as there is a conflict over the `moneta` gem. `locomotivecms 3.3.x` uses `locomotivecms_steam 1.3.0` which uses `moneta 1.0.0`, while even the most recent `platform-api 2.1.0` uses `moneta 0.8.1`.

Thank you again.