### PR TITLE
fixed regular expression used for multiline text

### DIFF
--- a/app/views/locomotive/notifications/new_content_entry.html.slim
+++ b/app/views/locomotive/notifications/new_content_entry.html.slim
@@ -17,7 +17,7 @@ ul
       i
         - case field.type.to_s
         - when 'text'
-          = raw(value.gsub(/(\r\n|\r|\n)/, '<br/>'))
+          = raw(value.gsub(/(\\r\\n|\\r|\\n)/, '<br/>'))
         - when 'file'
           - url = value.guess_url
           - url = url =~ /^http/ ? url : URI.join("http://#{@domain}", url).to_s # Amazon S3 (http/https) or local files ?


### PR DESCRIPTION
Let's see following example.

```
# define "this is my cat" with using multiline chars
value = 'this\n is \n\r my \r\r cat'
value.gsub(/(\r\n|\r|\n)/, '<br/>')
  =>  "this\\n is \\n\\r my \\r\\r cat"
# but
value.gsub(/(\\r\\n|\\r|\\n)/, '<br/>')
 => "this<br/> is <br/><br/> my <br/><br/> cat"
```