### PR TITLE
Avoids ambiguity

### DIFF
--- a/app/policies/locomotive/site_policy.rb
+++ b/app/policies/locomotive/site_policy.rb
@@ -1,7 +1,7 @@
 module Locomotive
   class SitePolicy < ApplicationPolicy
 
-    class Scope < Scope
+    class Scope < ApplicationPolicy::Scope
 
       def resolve
         if membership.account.super_admin?


### PR DESCRIPTION
In a project using ruby-2.4.1, engine-3.3.0.rc3 and sidekiq-5.0.4, when I run `bundle exec sidekiq` I get the following error:

```bash
superclass mismatch for class Scope
/korujas/vendor/gems/engine/app/policies/locomotive/site_policy.rb:4:in `<class:SitePolicy>'
```