### PR TITLE
Use "Digest::MD5.hexdigest" for hash long string

### DIFF
--- a/lib/locomotive/steam/services/liquid_parser_with_cache_service.rb
+++ b/lib/locomotive/steam/services/liquid_parser_with_cache_service.rb
@@ -14,7 +14,8 @@ module Locomotive
       end
 
       def cache_key(page)
-        "#{Locomotive::VERSION}/site/#{current_site._id}/template/#{current_site.template_version.to_i}/page/#{page._id}/#{locale}"
+        key = "#{Locomotive::VERSION}/site/#{current_site._id}/template/#{current_site.template_version.to_i}/page/#{page._id}/#{locale}"
+        Digest::MD5.hexdigest(key)
       end
 
       private


### PR DESCRIPTION
Use Digest::MD5.hexdigest(key) for hash long string in the "cache_key" method.
Just do in the same way like in the "engine\lib\locomotive\steam\middlewares\cache.rb" file.