### PR TITLE
Update zh-CN.yml

### DIFF
--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,7 +1,7 @@
 zh-CN:
   locomotive:
     locales:
-      en: 中文
+      en: 英文
       de: 德文
       fr: 法文
       pl: 波兰


### PR DESCRIPTION
Corrected English ISO type to the correct translation to address the locale switcher in issue #1234 