### PR TITLE
Fixes: #1237

### DIFF
--- a/app/inputs/locomotive/array_input.rb
+++ b/app/inputs/locomotive/array_input.rb
@@ -66,7 +66,8 @@ module Locomotive
       if options[:select_options]
         template.select_tag(singularized_name, template.options_for_select(options[:select_options]), class: css)
       elsif data = options[:picker]
-        template.select_tag('id', '', class: css, data: data)
+        tag_id = options.dig(:template, :locals, :slug) || options[:label].underscore
+        template.select_tag("content_entry_#{tag_id}", '', class: css, data: data)
       else
         text_options = input_html_options.dup
         text_options[:class] << css


### PR DESCRIPTION
This took way too long for figure out. In the end, it seems to have been an issue with the duplicate IDs, even though it was fine before. I'm guessing there was a change in the select2 js that was introduced here c2136a1.

 FYI: This uses Hash#dig which only works with Ruby > 2.3