### PR TITLE
Open sidebar collapse menus when active

### DIFF
--- a/app/views/locomotive/shared/_sidebar.html.slim
+++ b/app/views/locomotive/shared/_sidebar.html.slim
@@ -8,7 +8,7 @@
       span= t('.dashboard')
 
     - cache(cache_key_for_sidebar_pages) do
-      = link_to '#collapsePages', data: { toggle: 'collapse' }, aria: { expanded: 'false', controls: 'collapsePages' }, class: sidebar_link_class(:pages) do
+      = link_to '#collapsePages', data: { toggle: 'collapse' }, aria: { expanded: request.path.include?("/pages/").to_s, controls: 'collapsePages' }, class: sidebar_link_class(:pages) do
         i.far.fa-file-alt
         span= t('.pages')
         i.fa.fa-caret-down

--- a/app/views/locomotive/shared/sidebar/_content_types.html.slim
+++ b/app/views/locomotive/shared/sidebar/_content_types.html.slim
@@ -1,12 +1,14 @@
 - list = Locomotive::ContentTypeService.new(current_site).list
 
 - unless list.empty?
-  = link_to '#collapseContentTypes', data: { toggle: 'collapse' }, aria: { expanded: 'false', controls: 'collapseContentTypes' }, class: sidebar_link_class(:content_types) do
+  - active = params[:controller].include?('content_types')
+
+  = link_to '#collapseContentTypes', data: { toggle: 'collapse' }, aria: { expanded: active.to_s, controls: 'collapseContentTypes' }, class: sidebar_link_class(:content_types) do
     i.fas.fa-list
     span= t('.title')
     i.fa.fa-caret-down
 
-  ul.sidebar-list.collapse#collapseContentTypes
+  ul.sidebar-list.collapse#collapseContentTypes class=('in' if active)
     - list.each do |content_type|
       - if policy(content_type).show?
         li

--- a/app/views/locomotive/shared/sidebar/_pages.html.slim
+++ b/app/views/locomotive/shared/sidebar/_pages.html.slim
@@ -1,5 +1,5 @@
 .pages-tree
-  ul.root.sidebar-list.collapse#collapsePages data-url=sort_page_path(current_site, root)
+  ul.root.sidebar-list.collapse#collapsePages data-url=sort_page_path(current_site, root) class=('in' if request.path.include?("/pages/").to_s)
     = render partial: 'locomotive/shared/sidebar/page', collection: nodes
 
     li.sidebar-list-add


### PR DESCRIPTION
Before: In the sidebar, when active/selected, Models and Pages collapse lists default to closed when page load.

After: In the sidebar, when active/selected, Models or Pages collapse lists are now open when page loads.