### PR TITLE
Change cursor to `move` on draggable pages within Sidebar

### DIFF
--- a/app/assets/stylesheets/locomotive/new/_sidebar.scss
+++ b/app/assets/stylesheets/locomotive/new/_sidebar.scss
@@ -14,6 +14,10 @@
   overflow: auto;
   background: $gray-darkest;
   transition: left $base-transition-speed linear;
+  
+  .draggable:hover{
+     cursor: move;
+  }
 }
 
 // Sidebar top logo in the sidebar.


### PR DESCRIPTION
Maybe it would be better for this to be a global css rule? Not sure where to put it in that case.