### PR TITLE
Change title format

### DIFF
--- a/app/views/locomotive/shared/_head.html.slim
+++ b/app/views/locomotive/shared/_head.html.slim
@@ -1,5 +1,5 @@
 - if current_site
-  title== escape_once("#{Locomotive.config.name} &mdash; #{current_site.name}")
+  title== escape_once("#{current_site.name} &mdash; #{Locomotive.config.name}")
 - else
   title= escape_once(Locomotive.config.name)
 


### PR DESCRIPTION
Tabs are only so wide. Currently the unique identifier (site title) is at the end of the title and getting snipped making the tab title useless when you have multiple sites open in different tabs. This PR swaps the order so the the unique identifier is always visible with the redundant CMS name getting snipped when width is not available.