### PR TITLE
Remove Reference to Trello

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Visit the Locomotive official website [here](https://www.locomotivecms.com) for 
 
 ## Contribute
 
-Have a look at our [Trello](https://trello.com/b/kRiy1dZu/locomotive-v3) board to see what's next or see where you can help out.
-
 ### Technologies
 
 Here is a list of the main gems used to power the Locomotive platform:


### PR DESCRIPTION
Remove reference to Trello. Last activity was almost a year ago Sep 28, 2018 at 6:37 AM. Github should be the only place to track this stuff.