### PR TITLE
Fix webpack production build error

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,6 +1,6 @@
 const config = require('./development.js');
 
-config.target = 'node'
+config.target = 'web'
 config.mode   = 'production';
 config.optimization = { minimize: true };
 


### PR DESCRIPTION
After running the production build I was getting an error

```
global is not defined
```

This problem did not appear in the development build, changing the webpack production `config.target` from `node` to `web` solves the issue.