### PR TITLE
Support different endpoint for S3 storage

### DIFF
--- a/lib/generators/locomotive/install/templates/carrierwave_aws.rb
+++ b/lib/generators/locomotive/install/templates/carrierwave_aws.rb
@@ -22,6 +22,13 @@ CarrierWave.configure do |config|
       region:             ENV['S3_BUCKET_REGION']
     }
 
+    # Use a different endpoint (eg: another provider such as Exoscale)
+    if ENV['S3_ENDPOINT'].present?
+      config.aws_credentials.config: AWS.config({
+        s3_endpoint: ENV['S3_ENDPOINT']
+      })
+    end
+
     # Put your CDN host below instead
     if ENV['S3_ASSET_HOST_URL'].present?
       config.asset_host = ENV['S3_ASSET_HOST_URL']

--- a/lib/generators/locomotive/install/templates/carrierwave_aws.rb
+++ b/lib/generators/locomotive/install/templates/carrierwave_aws.rb
@@ -24,7 +24,7 @@ CarrierWave.configure do |config|
 
     # Use a different endpoint (eg: another provider such as Exoscale)
     if ENV['S3_ENDPOINT'].present?
-      config.aws_credentials.config: AWS.config({
+      config.aws_credentials.config = AWS.config({
         s3_endpoint: ENV['S3_ENDPOINT']
       })
     end

--- a/lib/generators/locomotive/install/templates/carrierwave_aws.rb
+++ b/lib/generators/locomotive/install/templates/carrierwave_aws.rb
@@ -24,9 +24,7 @@ CarrierWave.configure do |config|
 
     # Use a different endpoint (eg: another provider such as Exoscale)
     if ENV['S3_ENDPOINT'].present?
-      config.aws_credentials.config = AWS.config({
-        s3_endpoint: ENV['S3_ENDPOINT']
-      })
+      config.aws_credentials[:endpoint] = ENV['S3_ENDPOINT']
     end
 
     # Put your CDN host below instead


### PR DESCRIPTION
As documented here https://github.com/sorentwo/carrierwave-aws/issues/40 this is the way to support another S3 storage provider.

/cc @sebastienbeau 