### PR TITLE
Fix link to content_type when content_type.entry_template is defined

### DIFF
--- a/app/helpers/locomotive/content_types_helper.rb
+++ b/app/helpers/locomotive/content_types_helper.rb
@@ -21,7 +21,8 @@ module Locomotive
         registers = { site: current_site, locale: current_content_locale.to_s, services: Locomotive::Steam::Services.build_instance }
         context   = ::Liquid::Context.new({}, assigns, registers)
 
-        content_type.render_entry_template(context).html_safe
+        label = content_type.render_entry_template(context).html_safe
+        link_to label, link # custom link
       end
     end
 


### PR DESCRIPTION
Fixes bug - https://github.com/locomotivecms/engine/issues/1352

content_type label customized with 'entry_template' should now render the correct link to the entry