### PR TITLE
Allow .webm theme asset upload

### DIFF
--- a/app/uploaders/locomotive/theme_asset_uploader.rb
+++ b/app/uploaders/locomotive/theme_asset_uploader.rb
@@ -10,7 +10,7 @@ module Locomotive
     end
 
     def extension_whitelist
-      %w(jpg jpeg gif png css js swf flv mp4 eot svg svgz ttf ttc woff woff2 otf ico htc map html cur txt xml json ogv)
+      %w(jpg jpeg gif png css js swf flv mp4 eot svg svgz ttf ttc woff woff2 otf ico htc map html cur txt xml json ogv webm)
     end
 
     def apply_content_type_exception(value)


### PR DESCRIPTION
I'm setting up some header with background video.
It requires three formats : .mp4 .ogv and .webm that is missing