### PR TITLE
width and height can be empy if dragonfly fail

### DIFF
--- a/app/models/locomotive/concerns/asset/vignette.rb
+++ b/app/models/locomotive/concerns/asset/vignette.rb
@@ -5,7 +5,9 @@ module Locomotive
 
         def vignette_url
           if self.image?
-            if self.width < 85 && self.height < 85
+            # In some case (like an invalid extension) the height, width can be nill
+            # In that case we should directly return the url
+            if self.width && self.height && self.width < 85 && self.height < 85
               self.source.url
             else
               Locomotive::Dragonfly.resize_url(self.source, '85x85#')


### PR DESCRIPTION
If you upload a broken image but considered as an image
the height and width will be empty and the comparison
with a number for checking the size will fail

Return the origin url if height width are nill