### PR TITLE
Workaround stack trace when switching language

### DIFF
--- a/app/helpers/locomotive/shared/pages_helper.rb
+++ b/app/helpers/locomotive/shared/pages_helper.rb
@@ -104,7 +104,7 @@ module Locomotive
         end
 
         def templatized_parent?
-          parent.templatized?
+          parent && parent.templatized?
         end
 
         def templatized_children?


### PR DESCRIPTION
We have experienced stack traces after adding a new language in `config.site_locales` and attempting to switch language in content Models.

This work around this issue. There might be a deeper root cause though.

Here is the stack trace we got:

```
F, [2020-09-23T15:06:49.234265 #18938] FATAL -- :
F, [2020-09-23T15:06:49.234438 #18938] FATAL -- : ActionView::Template::Error (undefined method `templatized?' for nil:NilClass):
F, [2020-09-23T15:06:49.234640 #18938] FATAL -- :     3:     - url = page.redirect? ? edit_page_path(current_site, page) : edit_page_content_path(current_site, page)
    4:
    5:     = link_to url do
    6:       - if page.draggable?
    7:         i class="fas fa-bars icon #{page.draggable}"
    8:       - else
    9:         i class="far fa-file-alt"
F, [2020-09-23T15:06:49.234687 #18938] FATAL -- :
F, [2020-09-23T15:06:49.234753 #18938] FATAL -- : vendor/bundle/ruby/2.6.0/bundler/gems/engine-bb2a3a3fa24a/app/helpers/locomotive/shared/pages_helper.rb:107:in `templatized_parent?'
vendor/bundle/ruby/2.6.0/bundler/gems/engine-bb2a3a3fa24a/app/helpers/locomotive/shared/pages_helper.rb:103:in `draggable?'
vendor/bundle/ruby/2.6.0/bundler/gems/engine-bb2a3a3fa24a/app/views/locomotive/shared/sidebar/_page.html.slim:6:in `block in _vendor_bundle_ruby_______bundler_gems_engine_bb_a_a_fa__a_app_views_locomotive_shared_sidebar__page_html_slim__127273452265101873_7005139095
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/capture_helper.rb:41:in `block in capture'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/capture_helper.rb:205:in `with_output_buffer'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/capture_helper.rb:41:in `capture'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/tag_helper.rb:272:in `content_tag'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/url_helper.rb:205:in `link_to'
vendor/bundle/ruby/2.6.0/bundler/gems/engine-bb2a3a3fa24a/app/views/locomotive/shared/sidebar/_page.html.slim:5:in `_vendor_bundle_ruby_______bundler_gems_engine_bb_a_a_fa__a_app_views_locomotive_shared_sidebar__page_html_slim__127273452265101873_70051390956260'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/template.rb:159:in `block in render'
vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:170:in `instrument'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/template.rb:354:in `instrument_render_template'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/template.rb:157:in `render'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:441:in `block in collection_with_template'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:437:in `map'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:437:in `collection_with_template'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:327:in `block (2 levels) in render_collection'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer/collection_caching.rb:15:in `cache_collection_render'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:326:in `block in render_collection'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/abstract_renderer.rb:44:in `block in instrument'
vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:168:in `block in instrument'
vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.4/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:168:in `instrument'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/abstract_renderer.rb:43:in `instrument'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:319:in `render_collection'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:310:in `render'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/renderer.rb:49:in `render_partial'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/renderer.rb:23:in `render'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/rendering_helper.rb:33:in `render'
vendor/bundle/ruby/2.6.0/bundler/gems/engine-bb2a3a3fa24a/app/views/locomotive/shared/sidebar/_pages.html.slim:3:in `_vendor_bundle_ruby_______bundler_gems_engine_bb_a_a_fa__a_app_views_locomotive_shared_sidebar__pages_html_slim__3385825182089673947_70051389737420'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/template.rb:159:in `block in render'
vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:170:in `instrument'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/template.rb:354:in `instrument_render_template'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/template.rb:157:in `render'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:344:in `block in render_partial'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/abstract_renderer.rb:44:in `block in instrument'
vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:168:in `block in instrument'
vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.4/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:168:in `instrument'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/abstract_renderer.rb:43:in `instrument'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:333:in `render_partial'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/partial_renderer.rb:312:in `render'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/renderer/renderer.rb:49:in `render_partial'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/rendering_helper.rb:36:in `render'
vendor/bundle/ruby/2.6.0/bundler/gems/engine-bb2a3a3fa24a/app/helpers/locomotive/shared/pages_helper.rb:49:in `render_pages'
vendor/bundle/ruby/2.6.0/bundler/gems/engine-bb2a3a3fa24a/app/views/locomotive/shared/_sidebar.html.slim:16:in `block (2 levels) in _vendor_bundle_ruby_______bundler_gems_engine_bb_a_a_fa__a_app_views_locomotive_shared__sidebar_html_slim___270611392578528681_4711706
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/cache_helper.rb:253:in `write_fragment_for'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/cache_helper.rb:243:in `fragment_for'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/cache_helper.rb:169:in `cache'
vendor/bundle/ruby/2.6.0/bundler/gems/engine-bb2a3a3fa24a/app/views/locomotive/shared/_sidebar.html.slim:10:in `block in _vendor_bundle_ruby_______bundler_gems_engine_bb_a_a_fa__a_app_views_locomotive_shared__sidebar_html_slim___270611392578528681_47117069107500'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/cache_helper.rb:253:in `write_fragment_for'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/cache_helper.rb:243:in `fragment_for'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/helpers/cache_helper.rb:169:in `cache'
vendor/bundle/ruby/2.6.0/bundler/gems/engine-bb2a3a3fa24a/app/views/locomotive/shared/_sidebar.html.slim:5:in `_vendor_bundle_ruby_______bundler_gems_engine_bb_a_a_fa__a_app_views_locomotive_shared__sidebar_html_slim___270611392578528681_47117069107500'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/template.rb:159:in `block in render'
vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:170:in `instrument'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/template.rb:354:in `instrument_render_template'
vendor/bundle/ruby/2.6.0/gems/actionview-5.2.4.4/lib/action_view/template.rb:157:in `render'

```