### PR TITLE
Localized fields don't render correctly in forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,16 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :development do
+  gem 'debug', '~> 1.9.2'
+  gem 'web-console', '~> 4.2.1'
+  gem 'error_highlight', '>= 0.4.0'
+end
+
 group :development, :test do 
   gem 'puma', '~> 6.4.0'
   gem 'rspec-rails', '~> 6.0.1'
-  gem 'capybara', '~> 3.39.0'
-  gem 'debug', '>= 1.0.0'
-  
+  gem 'capybara', '~> 3.39.0'  
   # gem 'custom_fields', path: '../custom_fields' # for Developers
   # gem 'custom_fields', github: 'locomotivecms/custom_fields', ref: 'd526dcb7bcb1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,7 @@ GEM
     bazaar (0.0.2)
     bcrypt (3.1.20)
     bigdecimal (3.1.4)
+    bindex (0.8.1)
     bootstrap-kaminari-views (0.0.5)
       kaminari (>= 0.13)
       rails (>= 3.1)
@@ -186,9 +187,9 @@ GEM
       database_cleaner-core (~> 2.0.0)
       mongoid
     date (3.3.4)
-    debug (1.8.0)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -224,6 +225,7 @@ GEM
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
       mail (~> 2.7)
+    error_highlight (0.6.0)
     erubi (1.12.0)
     execjs (2.9.1)
     factory_bot (6.4.0)
@@ -256,7 +258,7 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
-    irb (1.9.0)
+    irb (1.11.0)
       rdoc
       reline (>= 0.3.8)
     jbuilder (2.11.5)
@@ -523,6 +525,11 @@ GEM
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    web-console (4.2.1)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -543,8 +550,9 @@ PLATFORMS
 DEPENDENCIES
   capybara (~> 3.39.0)
   database_cleaner-mongoid (~> 2.0.1)
-  debug (>= 1.0.0)
+  debug (~> 1.9.2)
   email_spec (~> 2.2.1)
+  error_highlight (>= 0.4.0)
   factory_bot_rails (~> 6.4.0)
   json_spec (~> 1.1.5)
   locomotivecms!
@@ -554,6 +562,7 @@ DEPENDENCIES
   selenium-webdriver (= 4.10)
   shoulda-matchers (~> 5.3.0)
   simplecov
+  web-console (~> 4.2.1)
   webdrivers (~> 5.3.1)
 
 BUNDLED WITH

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
   factory :site, class: Locomotive::Site do
     name { 'Acme Website' }
     handle { 'acme' }
+    locales { ['en'] }
     # sequence(:handle) { |n| "acme#{n*rand(10_000)}" }
     created_at { Time.now }
 

--- a/spec/system/edit_site_spec.rb
+++ b/spec/system/edit_site_spec.rb
@@ -10,5 +10,10 @@ describe 'Editing a site' do
     click_button 'Save'
     expect(page).to have_content('My site was successfully updated.')
   end
-
+ 
+  it 'does not leak locales into input\'s value' do
+    click_button 'Save'
+    click_link 'SEO'
+    expect(page).not_to have_field('site_seo_title', with: 'en ')
+  end
 end


### PR DESCRIPTION
**Explanation**:

The Rails ActionView inputs get the value of a field from the <FIELD>_before_type_cast method if it exists.
In Mongoid 7, the Mongoid core team implemented the `_before_type_cast?` / `_before_type_cast` for ALL the fields including the localized ones.

Incidentally, it breaks the form inputs for localized fields. 

This patch restores the old behavior for localized fiels by implementing the X_came_from_user? method which makes the form inputs use the translated value of a field.