### PR TITLE
Update default_values.rb to allow unsetting of content_types group_by

### DIFF
--- a/app/models/locomotive/concerns/content_type/default_values.rb
+++ b/app/models/locomotive/concerns/content_type/default_values.rb
@@ -32,6 +32,23 @@ module Locomotive
           end
         end
 
+        def set_group_by
+          # Use .present? to check for not nil AND not empty string
+          if @group_by.present
+            field = self.find_entries_custom_field(@group_by)
+            # A valid field name was provided, and the field was found
+            if field
+              self.group_by_field_id = field._id
+            # A field name was provided, but it's invalid or not found
+            else
+              self.group_by_field_id = nil
+            end
+          # @group_by is nil or an empty string (intention to unset grouping)
+          else
+            self.group_by_field_id = nil
+          end
+        end
+
         def set_label_field
           if @new_label_field_name.present?
             self.label_field_id = self.entries_custom_fields.detect { |f| f.name == @new_label_field_name.underscore }.try(:_id)


### PR DESCRIPTION
Once `group_by` is set in a `content_type` definition file and deployed to Engine, there is no way to un-set it and remove the grouping. This update provides a solution by recognising when `group_by` is set to `nil` or `''` (empty string).

Fixes #1418