### PR TITLE
fix: set the local fallbacks for the new locales

### DIFF
--- a/app/services/locomotive/site_service.rb
+++ b/app/services/locomotive/site_service.rb
@@ -67,6 +67,9 @@ module Locomotive
     def localize_pages_and_content_entries(site, new_locales, previous_default_locale)
       return unless new_locales.present?
 
+      # set the fallbacks for the new locales, without it we will get an error when trying to localize the pages
+      set_fallbacks(site, new_locales)
+
       # localize all the existing pages
       page_service.site = site
       page_service.localize(new_locales, previous_default_locale)
@@ -81,6 +84,12 @@ module Locomotive
     def unique_handle
       Bazaar.heroku do |value|
         Site.where(handle: value).exists?
+      end
+    end
+
+    def set_fallbacks(site, new_locales)
+      new_locales.each do |locale|
+        ::Mongoid::Fields::I18n.fallbacks_for(locale, site.locale_fallbacks(locale))
       end
     end
 

--- a/spec/controllers/locomotive/current_site_controller_spec.rb
+++ b/spec/controllers/locomotive/current_site_controller_spec.rb
@@ -64,11 +64,19 @@ describe Locomotive::CurrentSiteController do
       end
     end
 
-    describe 'update locales' do
+    describe 'add a new locale' do
       let(:attributes) { { locales: ["en", "fr"] } }
       it "updates the locales" do
         subject
         expect(assigns(:site).locales).to eq(["en", "fr"])
+      end
+    end
+
+    describe 'replace the default locale' do
+      let(:attributes) { { locales: ["fr"] } }
+      it "updates the locales" do
+        subject
+        expect(assigns(:site).locales).to eq(["fr"])
       end
     end
 

--- a/spec/controllers/locomotive/current_site_controller_spec.rb
+++ b/spec/controllers/locomotive/current_site_controller_spec.rb
@@ -62,7 +62,14 @@ describe Locomotive::CurrentSiteController do
         end
 
       end
+    end
 
+    describe 'update locales' do
+      let(:attributes) { { locales: ["en", "fr"] } }
+      it "updates the locales" do
+        subject
+        expect(assigns(:site).locales).to eq(["en", "fr"])
+      end
     end
 
   end


### PR DESCRIPTION
When adding a new locale in an existing thru the Admin UI, we'd face the following error:

<img width="1046" height="554" alt="Screenshot 2025-07-31 at 16 44 51" src="https://github.com/user-attachments/assets/4d603dc8-8943-423f-a6bb-d80121d792a4" />

`NoMethodError in Locomotive::CurrentSiteController#update`