### PR TITLE
fix: no fallback for an unregistered locale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development, :test do
   gem "rack", "3.1.8"
 
   # gem 'custom_fields', path: '../custom_fields' # for Developers
-  gem 'custom_fields', github: 'locomotivecms/custom_fields', ref: '87bf1b389d'
+  gem 'custom_fields', github: 'locomotivecms/custom_fields', ref: '85e9c1a03c'
 
   # gem 'locomotivecms_common', path: '../common', require: false
   # gem 'locomotivecms_common', github: 'locomotivecms/common', ref: '054505c', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/locomotivecms/custom_fields.git
-  revision: 87bf1b389dcb710f3261abb3380a6da97cad1095
-  ref: 87bf1b389d
+  revision: 85e9c1a03c861d9e7cc70d77950af93f5511518f
+  ref: 85e9c1a03c
   specs:
     custom_fields (2.14.0.alpha1)
       activesupport (>= 7, < 8.0)

--- a/app/services/locomotive/site_service.rb
+++ b/app/services/locomotive/site_service.rb
@@ -67,9 +67,6 @@ module Locomotive
     def localize_pages_and_content_entries(site, new_locales, previous_default_locale)
       return unless new_locales.present?
 
-      # set the fallbacks for the new locales, without it we will get an error when trying to localize the pages
-      set_fallbacks(site, new_locales)
-
       # localize all the existing pages
       page_service.site = site
       page_service.localize(new_locales, previous_default_locale)
@@ -86,12 +83,5 @@ module Locomotive
         Site.where(handle: value).exists?
       end
     end
-
-    def set_fallbacks(site, new_locales)
-      new_locales.each do |locale|
-        ::Mongoid::Fields::I18n.fallbacks_for(locale, site.locale_fallbacks(locale))
-      end
-    end
-
   end
 end

--- a/docker/mongo-init/01-init-locomotive.js
+++ b/docker/mongo-init/01-init-locomotive.js
@@ -54,3 +54,17 @@ db.createCollection('theme_assets');
 db.createCollection('translations');
 
 print('LocomotiveCMS test database initialized successfully');
+
+// Create a new database for the custom fields
+db = db.getSiblingDB('custom_fields_test');
+
+db.createUser({
+  user: 'admin',
+  pwd: 'password',
+  roles: [
+    {
+      role: 'readWrite',
+      db: 'custom_fields_test'
+    }
+  ]
+});


### PR DESCRIPTION
It was fixed in the custom_fields gem there -> https://github.com/locomotivecms/custom_fields/commit/85e9c1a03c861d9e7cc70d77950af93f5511518f