### PR TITLE
Add options_editable option to select content_type fields

### DIFF
--- a/app/api/locomotive/api/entities/content_type_field_entity.rb
+++ b/app/api/locomotive/api/entities/content_type_field_entity.rb
@@ -10,6 +10,8 @@ module Locomotive
         expose :text_formatting, if: ->(field, _) { field.type.to_s == 'text' }
 
         # select type field
+        expose :options_editable, if: ->(field, _) { field.type.to_s == 'select' }
+        
         expose :select_options, if: ->(field, _) { field.type.to_s == 'select' } do |field, _|
           field.select_options.map do |option|
             { id: option._id, name: option.name_translations, position: option.position }

--- a/app/api/locomotive/api/forms/content_type_field_form.rb
+++ b/app/api/locomotive/api/forms/content_type_field_form.rb
@@ -10,7 +10,7 @@ module Locomotive
               :required, :localized, :unique, :position,
               :text_formatting, :select_options_attributes,
               :target, :inverse_of, :order_by, :ui_enabled,
-              :group, :default, :class_name, :_destroy
+              :options_editable, :group, :default, :class_name, :_destroy
 
         def initialize(content_type_service, existing_field, attributes)
           self.content_type_service = content_type_service

--- a/app/api/locomotive/api/resources/content_type_resource.rb
+++ b/app/api/locomotive/api/resources/content_type_resource.rb
@@ -50,6 +50,7 @@ module Locomotive
                 optional :position
                 optional :text_formatting
                 optional :select_options
+                optional :options_editable
                 optional :target
                 optional :inverse_of
                 optional :order_by
@@ -101,6 +102,7 @@ module Locomotive
                 optional :position
                 optional :text_formatting
                 optional :select_options
+                optional :options_editable
                 optional :target
                 optional :inverse_of
                 optional :order_by

--- a/app/controllers/locomotive/custom_fields/select_options_controller.rb
+++ b/app/controllers/locomotive/custom_fields/select_options_controller.rb
@@ -8,6 +8,7 @@ module Locomotive
 
       before_action :load_content_type
       before_action :load_custom_field
+      before_action :ensure_options_editable
 
       def edit
         respond_with @custom_field
@@ -36,6 +37,10 @@ module Locomotive
 
       def load_custom_field
         @custom_field = @content_type.entries_custom_fields.where(name: params[:name]).first
+      end
+
+      def ensure_options_editable
+        head :forbidden unless @custom_field.options_editable?
       end
 
       def service

--- a/app/helpers/locomotive/custom_fields_helper.rb
+++ b/app/helpers/locomotive/custom_fields_helper.rb
@@ -165,10 +165,10 @@ module Locomotive
         as:           :editable_select,
         wrapper_html: { class: 'select' },
         collection:   field.ordered_select_options.map { |option| [option.name, option.id] },
-        manage_collection:    {
+        manage_collection: field.options_editable? ? {
           label:  custom_field_t(:edit, field.type),
           url:    edit_custom_fields_select_options_path(current_site, entry.content_type.slug, field.name)
-        }
+        } : nil
       }
     end
 

--- a/lib/locomotive/custom_fields.rb
+++ b/lib/locomotive/custom_fields.rb
@@ -8,6 +8,7 @@ module CustomFields
   class Field
 
     field :ui_enabled, type: Boolean, default: true
+    field :options_editable, type: Boolean, default: true
     field :group
 
     def class_name_to_content_type


### PR DESCRIPTION
Adds a new boolean field option, `options_editable` (default `true`), to `select` content type fields. When set to `false`, admin users editing a content entry can no longer add new options to that field via the Back Office's "Edit options" screen — the field itself remains fully usable, just not extensible.

This mirrors the existing `ui_enabled` option available on `has_many`/`many_to_many` fields, though it's a distinct flag rather than a reuse of `ui_enabled`, since `ui_enabled` already has an unrelated, broader meaning (whole-field visibility in the entry form) that doesn't fit this use case.

Motivation: some sites want a fixed, curated list of `select` options that only developers can change via Wagon/YAML, while others want admins free to expand the list from the Back Office. Currently this isn't configurable per-field.

Changes:
- `lib/locomotive/custom_fields.rb` — new `options_editable` field on the base `Field` model
- `app/api/locomotive/api/forms/content_type_field_form.rb` — whitelist the new attribute
- `app/api/locomotive/api/entities/content_type_field_entity.rb` — expose it for `select` fields
- `app/api/locomotive/api/resources/content_type_resource.rb` — accept it as an API param
- `app/controllers/locomotive/custom_fields/select_options_controller.rb` — enforce it (`before_action`, returns 403 if disabled) — this is the actual permission boundary, not just a UI nicety
- `app/helpers/locomotive/custom_fields_helper.rb` — hide the "Edit options" link when disabled
- Adds specs covering the new controller guard

Backward compatibility: defaults to `true`, so existing sites and fields are unaffected unless explicitly opted out.